### PR TITLE
feat: finish up the detailed integration status

### DIFF
--- a/packages/api/src/WithIntegrations.tsx
+++ b/packages/api/src/WithIntegrations.tsx
@@ -18,7 +18,9 @@ export interface IWithIntegrationsProps {
 
 export class WithIntegrations extends React.Component<IWithIntegrationsProps> {
   public changeFilter(change: IChangeEvent) {
-    return change.kind.startsWith('integration');
+    return (
+      change.kind === 'integration' || change.kind === 'integration-deployment'
+    );
   }
 
   public render() {
@@ -27,11 +29,10 @@ export class WithIntegrations extends React.Component<IWithIntegrationsProps> {
         url={'/integrations'}
         defaultValue={{ items: [], totalCount: 0 }}
       >
-        {({ read, response }) => {
-          if (this.props.disableUpdates) {
-            return this.props.children(response);
-          }
-          return (
+        {({ read, response }) =>
+          this.props.disableUpdates ? (
+            this.props.children(response)
+          ) : (
             <ServerEventsContext.Consumer>
               {({ registerChangeListener, unregisterChangeListener }) => (
                 <WithChangeListener
@@ -44,8 +45,8 @@ export class WithIntegrations extends React.Component<IWithIntegrationsProps> {
                 </WithChangeListener>
               )}
             </ServerEventsContext.Consumer>
-          );
-        }}
+          )
+        }
       </SyndesisRest>
     );
   }

--- a/packages/models/src/extra.d.ts
+++ b/packages/models/src/extra.d.ts
@@ -20,7 +20,7 @@ export interface IntegrationMonitoring {
   value: string;
   id: string;
   integrationId: string;
-  linkType: string;
+  linkType: 'LOGS' | 'EVENTS';
   namespace: string;
   podName: string;
 }

--- a/packages/ui/src/IntegrationProgress.css
+++ b/packages/ui/src/IntegrationProgress.css
@@ -1,0 +1,7 @@
+.integration-progress {
+  width: 180px;
+}
+
+.integration-progress .integration-progress-value {
+  text-transform: capitalize;
+}

--- a/packages/ui/src/IntegrationProgress.tsx
+++ b/packages/ui/src/IntegrationProgress.tsx
@@ -1,10 +1,14 @@
-import { ProgressBar } from 'patternfly-react';
+import { Icon, ProgressBar } from 'patternfly-react';
 import * as React from 'react';
+
+import './IntegrationProgress.css';
 
 export interface IIntegrationProgressProps {
   value: string;
   currentStep: number;
   totalSteps: number;
+  logUrl?: string;
+  i18nLogUrlText: string;
 }
 
 export class IntegrationProgress extends React.PureComponent<
@@ -12,10 +16,19 @@ export class IntegrationProgress extends React.PureComponent<
 > {
   public render() {
     return (
-      <div>
+      <div className="integration-progress">
         <div>
-          {this.props.value} ( {this.props.currentStep} /{' '}
-          {this.props.totalSteps} )
+          <i data-testid="integration-progress-value">
+            {this.props.value} ( {this.props.currentStep} /{' '}
+            {this.props.totalSteps} )
+          </i>
+          {this.props.logUrl && (
+            <span data-testid="deployment-log-link" className="pull-right">
+              <a target="_blank" href={this.props.logUrl}>
+                {this.props.i18nLogUrlText} <Icon name={'external-link'} />
+              </a>
+            </span>
+          )}
         </div>
         <ProgressBar
           now={this.props.currentStep}

--- a/packages/ui/src/IntegrationStatus.tsx
+++ b/packages/ui/src/IntegrationStatus.tsx
@@ -1,10 +1,18 @@
 import { Label } from 'patternfly-react';
 import * as React from 'react';
+import {
+  ERROR,
+  IntegrationState,
+  PENDING,
+  PUBLISHED,
+  UNPUBLISHED,
+} from './sharedModels';
 
 export interface IIntegrationStatusProps {
-  currentState?: string;
+  currentState?: IntegrationState;
   i18nPublished: string;
   i18nUnpublished: string;
+  i18nError: string;
 }
 
 export class IntegrationStatus extends React.Component<
@@ -12,17 +20,22 @@ export class IntegrationStatus extends React.Component<
 > {
   public render() {
     const labelType =
-      this.props.currentState === 'Published' ||
-      this.props.currentState === 'Pending'
+      this.props.currentState === ERROR
+        ? 'danger'
+        : this.props.currentState === PUBLISHED ||
+          this.props.currentState === PENDING
         ? 'primary'
         : 'default';
-    let label = 'Pending';
+    let label = PENDING; // it's a parachute
     switch (this.props.currentState) {
-      case 'Published':
+      case PUBLISHED:
         label = this.props.i18nPublished;
         break;
-      case 'Unpublished':
+      case UNPUBLISHED:
         label = this.props.i18nUnpublished;
+        break;
+      case ERROR:
+        label = this.props.i18nError;
         break;
     }
     return <Label type={labelType}>{label}</Label>;

--- a/packages/ui/src/IntegrationStatusDetail.tsx
+++ b/packages/ui/src/IntegrationStatusDetail.tsx
@@ -1,38 +1,47 @@
 import { Spinner } from 'patternfly-react';
 import * as React from 'react';
 import { IntegrationProgress } from './IntegrationProgress';
+import { IntegrationState, PUBLISHED, UNPUBLISHED } from './sharedModels';
 
 import './IntegrationStatusDetail.css';
 
 export interface IIntegrationStatusDetailProps {
-  targetState: string;
+  targetState: IntegrationState;
   value?: string;
   currentStep?: number;
   totalSteps?: number;
+  logUrl?: string;
+  i18nProgressPending: string;
   i18nProgressStarting: string;
   i18nProgressStopping: string;
+  i18nLogUrlText: string;
 }
 
 export class IntegrationStatusDetail extends React.Component<
   IIntegrationStatusDetailProps
 > {
   public render() {
-    let fallbackText = 'Pending';
+    let fallbackText = this.props.i18nProgressPending;
     switch (this.props.targetState) {
-      case 'Published':
-        fallbackText = 'Starting...';
+      case PUBLISHED:
+        fallbackText = this.props.i18nProgressStarting;
         break;
-      case 'Unpublished':
-        fallbackText = 'Stopping...';
+      case UNPUBLISHED:
+        fallbackText = this.props.i18nProgressStopping;
         break;
     }
     return (
-      <div className={'integration-status-detail'}>
+      <div
+        data-testid="integration-status-detail"
+        className={'integration-status-detail'}
+      >
         {this.props.value && this.props.currentStep && this.props.totalSteps ? (
           <IntegrationProgress
             currentStep={this.props.currentStep}
             totalSteps={this.props.totalSteps}
             value={this.props.value}
+            logUrl={this.props.logUrl}
+            i18nLogUrlText={this.props.i18nLogUrlText}
           />
         ) : (
           <>

--- a/packages/ui/src/IntegrationsListItem.tsx
+++ b/packages/ui/src/IntegrationsListItem.tsx
@@ -2,21 +2,26 @@ import { DropdownKebab, Icon, ListView, MenuItem } from 'patternfly-react';
 import * as React from 'react';
 import { IntegrationStatus } from './IntegrationStatus';
 import { IntegrationStatusDetail } from './IntegrationStatusDetail';
+import { IntegrationState } from './sharedModels';
 
 export interface IIntegrationsListItemProps {
   integrationId: string;
   integrationName: string;
-  currentState: string;
-  targetState: string;
+  currentState: IntegrationState;
+  targetState: IntegrationState;
   isConfigurationRequired: boolean;
   monitoringValue?: string;
   monitoringCurrentStep?: number;
   monitoringTotalSteps?: number;
+  monitoringLogUrl?: string;
   i18nConfigurationRequired: string;
+  i18nError: string;
   i18nPublished: string;
+  i18nProgressPending: string;
   i18nProgressStarting: string;
   i18nProgressStopping: string;
   i18nUnpublished: string;
+  i18nLogUrlText: string;
 }
 
 export class IntegrationsListItem extends React.Component<
@@ -33,14 +38,18 @@ export class IntegrationsListItem extends React.Component<
                 value={this.props.monitoringValue}
                 currentStep={this.props.monitoringCurrentStep}
                 totalSteps={this.props.monitoringTotalSteps}
+                logUrl={this.props.monitoringLogUrl}
+                i18nProgressPending={this.props.i18nProgressPending}
                 i18nProgressStarting={this.props.i18nProgressStarting}
                 i18nProgressStopping={this.props.i18nProgressStopping}
+                i18nLogUrlText={this.props.i18nLogUrlText}
               />
             ) : (
               <IntegrationStatus
                 currentState={this.props.currentState}
                 i18nPublished={this.props.i18nPublished}
                 i18nUnpublished={this.props.i18nUnpublished}
+                i18nError={this.props.i18nError}
               />
             )}
             <DropdownKebab

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -20,3 +20,4 @@ export * from './LogViewer';
 export * from './PfNavLink';
 export * from './PfVerticalNavItem';
 export * from './UnrecoverableError';
+export * from './sharedModels';

--- a/packages/ui/src/sharedModels.ts
+++ b/packages/ui/src/sharedModels.ts
@@ -1,0 +1,17 @@
+// Integration states
+export const PUBLISHED = 'Published';
+export const UNPUBLISHED = 'Unpublished';
+export const PENDING = 'Pending';
+export const ERROR = 'Error';
+
+export type IntegrationState =
+  | 'Published'
+  | 'Unpublished'
+  | 'Pending'
+  | 'Error';
+
+// Detailed state log link types
+export const LOGS = 'LOGS';
+export const EVENTS = 'EVENTS';
+
+export type LinkType = 'LOGS' | 'EVENTS';

--- a/packages/ui/stories/IntegrationProgress.stories.tsx
+++ b/packages/ui/stories/IntegrationProgress.stories.tsx
@@ -1,0 +1,27 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { text } from '@storybook/addon-knobs';
+import { StoryHelper } from '../.storybook/StoryHelper';
+import { IntegrationProgress } from '../src';
+
+const stories = storiesOf('Components', module);
+
+stories
+  .addDecorator(story => <StoryHelper>{story()}</StoryHelper>)
+  .add('IntegrationProgress - Without Log Link', () => (
+    <IntegrationProgress
+      value={text('value', 'Building')}
+      currentStep={text('currentStep', '2')}
+      totalSteps={text('totalSteps', '4')}
+      i18nLogUrlText={text('i18nLogUrlText', 'View Log')}
+    />
+  ))
+  .add('IntegrationProgress - With Log Link', () => (
+    <IntegrationProgress
+      value={text('value', 'Deploying')}
+      currentStep={text('currentStep', '3')}
+      totalSteps={text('totalSteps', '4')}
+      logUrl={text('logUrl', 'http://localhost:9001')}
+      i18nLogUrlText={text('i18nLogUrlText', 'View Log')}
+    />
+  ));

--- a/packages/ui/stories/IntegrationStatusDetail.stories.tsx
+++ b/packages/ui/stories/IntegrationStatusDetail.stories.tsx
@@ -1,0 +1,31 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { text } from '@storybook/addon-knobs';
+import { StoryHelper } from '../.storybook/StoryHelper';
+import { IntegrationStatusDetail } from '../src';
+
+const stories = storiesOf('Components', module);
+
+stories
+  .addDecorator(story => <StoryHelper>{story()}</StoryHelper>)
+  .add('IntegrationStatusDetail - Without Detail', () => (
+    <IntegrationStatusDetail
+      targetState={text('targetState', 'Published')}
+      i18nProgressPending={'Pending'}
+      i18nProgressStarting={'Starting...'}
+      i18nProgressStopping={'Stopping...'}
+      i18nLogUrlText={'View Log'}
+    />
+  ))
+  .add('IntegrationStatusDetail - With Detail', () => (
+    <IntegrationStatusDetail
+      value={text('value', 'Building')}
+      targetState={text('targetState', 'Published')}
+      currentStep={text('currentStep', '2')}
+      totalSteps={text('totalSteps', '4')}
+      i18nProgressPending={'Pending'}
+      i18nProgressStarting={'Starting...'}
+      i18nProgressStopping={'Stopping...'}
+      i18nLogUrlText={'View Log'}
+    />
+  ));

--- a/packages/ui/tests/ConnectionCard.spec.tsx
+++ b/packages/ui/tests/ConnectionCard.spec.tsx
@@ -1,8 +1,8 @@
-import { render } from 'react-testing-library';
 import * as React from 'react';
+import { render } from 'react-testing-library';
 import { ConnectionCard } from '../src';
 
-export default describe('ConnectionCard', function() {
+export default describe('ConnectionCard', () => {
   const testComponent = (
     <ConnectionCard
       name={'Sample connection'}
@@ -13,7 +13,7 @@ export default describe('ConnectionCard', function() {
     />
   );
 
-  it('Should have the Sample connection title', function() {
+  it('Should have the Sample connection title', () => {
     const { getByTestId } = render(testComponent);
     expect(getByTestId('connection-card-title')).toHaveTextContent(
       'Sample connection'

--- a/packages/ui/tests/IntegrationProgress.spec.tsx
+++ b/packages/ui/tests/IntegrationProgress.spec.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { render } from 'react-testing-library';
+import { IntegrationProgress } from '../src';
+
+export default describe('IntegrationProgress', () => {
+  // Component with a log link
+  const testComponent = (
+    <IntegrationProgress
+      value={'Deploying'}
+      currentStep={2}
+      totalSteps={4}
+      logUrl={'http://localhost:9000/'}
+      i18nLogUrlText={'View Logs'}
+    />
+  );
+
+  // Component without a log link
+  const testComponentNoLog = (
+    <IntegrationProgress
+      value={'Assembling'}
+      currentStep={1}
+      totalSteps={4}
+      i18nLogUrlText={'View Logs'}
+    />
+  );
+
+  it('Should show the progress value and steps', () => {
+    const { getByTestId } = render(testComponent);
+    expect(getByTestId('integration-progress-value')).toHaveTextContent(
+      'Deploying ( 2 / 4 )'
+    );
+  });
+  it('Should show the log link when supplied', () => {
+    const { queryByTestId } = render(testComponent);
+    expect(queryByTestId('deployment-log-link')).toBeDefined();
+    expect(queryByTestId('deployment-log-link')).toHaveTextContent('View Logs');
+  });
+  it('Should show the progress value and steps', () => {
+    const { getByTestId } = render(testComponentNoLog);
+    expect(getByTestId('integration-progress-value')).toHaveTextContent(
+      'Assembling ( 1 / 4 )'
+    );
+  });
+  it('Should not show the log link if not supplied', () => {
+    const { queryByTestId } = render(testComponentNoLog);
+    expect(queryByTestId('deployment-log-link')).toEqual(null);
+  });
+});

--- a/packages/ui/tests/IntegrationStatusDetail.spec.tsx
+++ b/packages/ui/tests/IntegrationStatusDetail.spec.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { render } from 'react-testing-library';
+import { IntegrationStatusDetail } from '../src';
+
+export default describe('IntegrationStatusDetail', () => {
+  // Publishing state wwith no details
+  const testComponentPublishing = (
+    <IntegrationStatusDetail
+      targetState={'Published'}
+      i18nProgressPending={'Pending'}
+      i18nProgressStarting={'Starting...'}
+      i18nProgressStopping={'Stopping...'}
+      i18nLogUrlText={'View Log'}
+    />
+  );
+
+  const testComponentPublishingDetailed = (
+    <IntegrationStatusDetail
+      targetState={'Published'}
+      value={'Deploying'}
+      currentStep={2}
+      totalSteps={4}
+      i18nProgressPending={'Pending'}
+      i18nProgressStarting={'Starting...'}
+      i18nProgressStopping={'Stopping...'}
+      i18nLogUrlText={'View Log'}
+    />
+  );
+
+  // Unpublishing state
+  const testComponentUnpublishing = (
+    <IntegrationStatusDetail
+      targetState={'Unpublished'}
+      i18nProgressPending={'Pending'}
+      i18nProgressStarting={'Starting...'}
+      i18nProgressStopping={'Stopping...'}
+      i18nLogUrlText={'View Log'}
+    />
+  );
+
+  it('Should show the starting state', () => {
+    const { getByTestId } = render(testComponentPublishing);
+    expect(getByTestId('integration-status-detail')).toHaveTextContent(
+      'Starting...'
+    );
+  });
+
+  it('Should show the detailed status', () => {
+    const { getByTestId } = render(testComponentPublishingDetailed);
+    expect(getByTestId('integration-status-detail')).toHaveTextContent('');
+  });
+
+  it('Should show the stopping state', () => {
+    const { getByTestId } = render(testComponentUnpublishing);
+    expect(getByTestId('integration-status-detail')).toHaveTextContent(
+      'Stopping...'
+    );
+  });
+});

--- a/syndesis/src/app/App.tsx
+++ b/syndesis/src/app/App.tsx
@@ -3,6 +3,7 @@ import {
   ServerEventsContext,
   WithServerEvents,
 } from '@syndesis/api';
+import { IntegrationMonitoring } from '@syndesis/models';
 import {
   AppLayout,
   Loader,
@@ -18,7 +19,7 @@ import { NamespacesConsumer } from 'react-i18next';
 import { Route, RouteComponentProps, Switch } from 'react-router-dom';
 import './App.css';
 import { AppContext } from './AppContext';
-import { WithConfig } from './WithConfig';
+import { IConfigFile, WithConfig } from './WithConfig';
 
 import pictogram from './glasses_logo_square.png';
 import typogram from './syndesis-logo-svg-white.svg';
@@ -53,7 +54,11 @@ export class App extends React.Component<IAppBaseProps> {
               >
                 {() => (
                   <AppContext.Provider
-                    value={{ config: config!, logout: this.logout }}
+                    value={{
+                      config: config!,
+                      getPodLogUrl: this.getPodLogUrl,
+                      logout: this.logout,
+                    }}
                   >
                     <ApiContext.Provider
                       value={{
@@ -130,5 +135,31 @@ export class App extends React.Component<IAppBaseProps> {
 
   public logout = () => {
     // do nothing
+  };
+
+  public getPodLogUrl = (
+    config: IConfigFile,
+    monitoring: IntegrationMonitoring | undefined
+  ): string | undefined => {
+    if (
+      !config ||
+      !monitoring ||
+      !monitoring.linkType ||
+      !monitoring.namespace ||
+      !monitoring.podName
+    ) {
+      return undefined;
+    }
+    const baseUrl = `${config.consoleUrl}/project/${
+      monitoring.namespace
+    }/browse/pods/${monitoring.podName}?tab=`;
+    switch (monitoring.linkType) {
+      case 'LOGS':
+        return baseUrl + 'logs';
+      case 'EVENTS':
+        return baseUrl + 'events';
+      default:
+        return undefined;
+    }
   };
 }

--- a/syndesis/src/app/AppContext.tsx
+++ b/syndesis/src/app/AppContext.tsx
@@ -1,8 +1,13 @@
+import { IntegrationMonitoring } from '@syndesis/models';
 import * as React from 'react';
 import { IConfigFile } from './WithConfig';
 
 export interface IAppContext {
   config: IConfigFile;
+  getPodLogUrl: (
+    config: IConfigFile,
+    monitoring: IntegrationMonitoring | undefined
+  ) => string | undefined;
   logout(): void;
 }
 

--- a/syndesis/src/i18n/locales/shared-translations.en.json
+++ b/syndesis/src/i18n/locales/shared-translations.en.json
@@ -10,6 +10,7 @@
       "Connection": "Connection",
       "Connections": "Connections",
       "Customizations": "Customizations",
+      "Error": "Error",
       "filterByNamePlaceholder": "Filter by Name",
       "Home": "Home",
       "Import": "Import",
@@ -17,12 +18,14 @@
       "linkCreateConnection": "Create Connection",
       "linkCreateIntegration": "Create Integration",
       "Name": "Name",
-      "Published": "Published",
+      "Pending": "Pending",
+      "Published": "Running",
       "resultsCount": "{{count}} Results",
       "Settings": "Settings",
       "Status": "Status",
       "Total": "Total",
-      "Unpublished": "Unpublished"
+      "Unpublished": "Stopped",
+      "viewLogs": "View Logs"
     }
   }
 }

--- a/syndesis/src/i18n/locales/shared-translations.it.json
+++ b/syndesis/src/i18n/locales/shared-translations.it.json
@@ -10,6 +10,7 @@
       "Connection": "Connessione",
       "Connections": "Connessioni",
       "Customizations": "Personalizzazioni",
+      "Error": "Errore",
       "filterByNamePlaceholder": "Filtra per Nome",
       "Home": "Casa",
       "Import": "Importare",
@@ -17,12 +18,14 @@
       "linkCreateConnection": "Crea Connessione",
       "linkCreateIntegration": "Crea Integrazione",
       "Name": "Nome",
-      "Published": "Pubblicato",
+      "Pending": "Pendente",
+      "Published": "Funzionante",
       "resultsCount": "{{count}} Risultati",
       "Settings": "Impostazioni",
       "Status": "Stato",
       "Total": "Totale",
-      "Unpublished": "Inedito"
+      "Unpublished": "Fermato",
+      "viewLogs": "Visualizza i registri"
     }
   }
 }

--- a/syndesis/src/modules/dashboard/pages/DashboardPage.tsx
+++ b/syndesis/src/modules/dashboard/pages/DashboardPage.tsx
@@ -30,6 +30,7 @@ import { getConnectionIcon, WithLoader } from '@syndesis/utils';
 import { Grid } from 'patternfly-react';
 import * as React from 'react';
 import { NamespacesConsumer } from 'react-i18next';
+import { AppContext } from '../../../app/AppContext';
 
 export interface IIntegrationCountsByState {
   Error: number;
@@ -124,221 +125,258 @@ export default () => (
                 metricsData.topIntegrations
               );
               return (
-                <NamespacesConsumer
-                  ns={['dashboard', 'integrations', 'shared']}
-                >
-                  {t => (
-                    <Dashboard
-                      linkToIntegrations={'/integrations'}
-                      linkToIntegrationCreation={'/integration/create'}
-                      linkToConnections={'/connections'}
-                      linkToConnectionCreation={'/connection/create'}
-                      integrationsOverview={
-                        <AggregatedMetricCard
-                          title={t('titleTotalIntegrations', {
-                            count: integrationsData.totalCount,
-                          })}
-                          ok={
-                            integrationsData.totalCount -
-                            integrationStatesCount.Error
+                <AppContext.Consumer>
+                  {({ config, getPodLogUrl }) => (
+                    <NamespacesConsumer
+                      ns={['dashboard', 'integrations', 'shared']}
+                    >
+                      {t => (
+                        <Dashboard
+                          linkToIntegrations={'/integrations'}
+                          linkToIntegrationCreation={'/integration/create'}
+                          linkToConnections={'/connections'}
+                          linkToConnectionCreation={'/connection/create'}
+                          integrationsOverview={
+                            <AggregatedMetricCard
+                              title={t('titleTotalIntegrations', {
+                                count: integrationsData.totalCount,
+                              })}
+                              ok={
+                                integrationsData.totalCount -
+                                integrationStatesCount.Error
+                              }
+                              error={integrationStatesCount.Error}
+                            />
                           }
-                          error={integrationStatesCount.Error}
-                        />
-                      }
-                      connectionsOverview={
-                        <ConnectionsMetric
-                          count={connectionsData.totalCount}
-                          i18nTitle={t('titleTotalConnections', {
-                            count: connectionsData.totalCount,
-                          })}
-                        />
-                      }
-                      messagesOverview={
-                        <AggregatedMetricCard
-                          title={t('titleTotalMessages', {
-                            count: metricsData.messages,
-                          })}
-                          ok={metricsData.messages! - metricsData.errors!}
-                          error={metricsData.errors!}
-                        />
-                      }
-                      uptimeOverview={
-                        <UptimeMetric
-                          start={parseInt(metricsData.start!, 10)}
-                          i18nTitle={t('titleUptimeMetric')}
-                        />
-                      }
-                      topIntegrations={
-                        <TopIntegrationsCard
-                          i18nTitle={t('titleTopIntegrations', { count: 5 })}
-                          i18nLast30Days={t('lastNumberOfDays', {
-                            numberOfDays: 30,
-                          })}
-                          i18nLast60Days={t('lastNumberOfDays', {
-                            numberOfDays: 60,
-                          })}
-                          i18nLast90Days={t('lastNumberOfDays', {
-                            numberOfDays: 90,
-                          })}
-                        >
-                          <WithLoader
-                            error={false}
-                            loading={!hasIntegrations}
-                            loaderChildren={
-                              <IntegrationsListSkeleton width={500} />
-                            }
-                            errorChildren={<div>TODO</div>}
-                          >
-                            {() => (
-                              <IntegrationsList>
-                                {topIntegrations.map(
-                                  (mi: IntegrationWithMonitoring, index) => (
-                                    <IntegrationsListItem
-                                      integrationId={mi.integration.id!}
-                                      integrationName={mi.integration.name}
-                                      currentState={
-                                        mi.integration!.currentState!
-                                      }
-                                      targetState={mi.integration!.targetState!}
-                                      isConfigurationRequired={
-                                        !!(
-                                          mi.integration!.board!.warnings ||
-                                          mi.integration!.board!.errors ||
-                                          mi.integration!.board!.notices
-                                        )
-                                      }
-                                      monitoringValue={
-                                        mi.monitoring &&
-                                        mi.monitoring.detailedState.value
-                                      }
-                                      monitoringCurrentStep={
-                                        mi.monitoring &&
-                                        mi.monitoring.detailedState.currentStep
-                                      }
-                                      monitoringTotalSteps={
-                                        mi.monitoring &&
-                                        mi.monitoring.detailedState.totalSteps
-                                      }
-                                      key={index}
-                                      i18nConfigurationRequired={t(
-                                        'integrations:ConfigurationRequired'
-                                      )}
-                                      i18nPublished={t('shared:Published')}
-                                      i18nUnpublished={t('shared:Unpublished')}
-                                      i18nProgressStarting={t(
-                                        'integrations:progressStarting'
-                                      )}
-                                      i18nProgressStopping={t(
-                                        'integrations:progressStopping'
-                                      )}
-                                    />
-                                  )
-                                )}
-                              </IntegrationsList>
-                            )}
-                          </WithLoader>
-                        </TopIntegrationsCard>
-                      }
-                      integrationBoard={
-                        <IntegrationBoard
-                          runningIntegrations={integrationStatesCount.Published}
-                          pendingIntegrations={integrationStatesCount.Pending}
-                          stoppedIntegrations={
-                            integrationStatesCount.Unpublished
+                          connectionsOverview={
+                            <ConnectionsMetric
+                              count={connectionsData.totalCount}
+                              i18nTitle={t('titleTotalConnections', {
+                                count: connectionsData.totalCount,
+                              })}
+                            />
                           }
-                          i18nTitle={t('titleIntegrationBoard')}
-                          i18nIntegrationStatePending={t(
-                            'integrationStatePending'
-                          )}
-                          i18nIntegrationStateRunning={t(
-                            'integrationStateRunning'
-                          )}
-                          i18nIntegrationStateStopped={t(
-                            'integrationStateStopped'
-                          )}
-                          i18nIntegrations={t('shared:Integrations')}
-                          i18nTotal={t('shared:Total')}
-                        />
-                      }
-                      integrationUpdates={
-                        <RecentUpdatesCard
-                          i18nTitle={t('titleIntegrationUpdates')}
-                        >
-                          <WithLoader
-                            error={false}
-                            loading={!hasIntegrations}
-                            loaderChildren={<RecentUpdatesSkeleton />}
-                            errorChildren={<div>TODO</div>}
-                          >
-                            {() =>
-                              recentlyUpdatedIntegrations.map(i => (
-                                <Grid.Row key={i.id}>
-                                  <Grid.Col sm={5}>{i.name}</Grid.Col>
-                                  <Grid.Col sm={3}>
-                                    <IntegrationStatus
-                                      currentState={i.currentState}
-                                      i18nPublished={t('shared:Published')}
-                                      i18nUnpublished={t('shared:Unpublished')}
-                                    />
-                                  </Grid.Col>
-                                  <Grid.Col sm={4}>
-                                    {new Date(
-                                      i.updatedAt! || i.createdAt!
-                                    ).toLocaleString()}
-                                  </Grid.Col>
-                                </Grid.Row>
-                              ))
-                            }
-                          </WithLoader>
-                        </RecentUpdatesCard>
-                      }
-                      connections={
-                        <ConnectionsGrid>
-                          <WithLoader
-                            error={false}
-                            loading={!hasConnections}
-                            loaderChildren={
-                              <>
-                                {new Array(5).fill(0).map((_, index) => (
-                                  <ConnectionsGridCell key={index}>
-                                    <ConnectionSkeleton />
-                                  </ConnectionsGridCell>
-                                ))}
-                              </>
-                            }
-                            errorChildren={<div>TODO</div>}
-                          >
-                            {() =>
-                              connectionsData.items.map((c, index) => (
-                                <ConnectionsGridCell key={index}>
-                                  <ConnectionCard
-                                    name={c.name}
-                                    description={c.description || ''}
-                                    icon={getConnectionIcon(
-                                      c,
-                                      process.env.PUBLIC_URL
+                          messagesOverview={
+                            <AggregatedMetricCard
+                              title={t('titleTotalMessages', {
+                                count: metricsData.messages,
+                              })}
+                              ok={metricsData.messages! - metricsData.errors!}
+                              error={metricsData.errors!}
+                            />
+                          }
+                          uptimeOverview={
+                            <UptimeMetric
+                              start={parseInt(metricsData.start!, 10)}
+                              i18nTitle={t('titleUptimeMetric')}
+                            />
+                          }
+                          topIntegrations={
+                            <TopIntegrationsCard
+                              i18nTitle={t('titleTopIntegrations', {
+                                count: 5,
+                              })}
+                              i18nLast30Days={t('lastNumberOfDays', {
+                                numberOfDays: 30,
+                              })}
+                              i18nLast60Days={t('lastNumberOfDays', {
+                                numberOfDays: 60,
+                              })}
+                              i18nLast90Days={t('lastNumberOfDays', {
+                                numberOfDays: 90,
+                              })}
+                            >
+                              <WithLoader
+                                error={false}
+                                loading={!hasIntegrations}
+                                loaderChildren={
+                                  <IntegrationsListSkeleton width={500} />
+                                }
+                                errorChildren={<div>TODO</div>}
+                              >
+                                {() => (
+                                  <IntegrationsList>
+                                    {topIntegrations.map(
+                                      (
+                                        mi: IntegrationWithMonitoring,
+                                        index
+                                      ) => (
+                                        <IntegrationsListItem
+                                          integrationId={mi.integration.id!}
+                                          integrationName={mi.integration.name}
+                                          currentState={
+                                            mi.integration!.currentState!
+                                          }
+                                          targetState={
+                                            mi.integration!.targetState!
+                                          }
+                                          isConfigurationRequired={
+                                            !!(
+                                              mi.integration!.board!.warnings ||
+                                              mi.integration!.board!.errors ||
+                                              mi.integration!.board!.notices
+                                            )
+                                          }
+                                          monitoringValue={
+                                            mi.monitoring &&
+                                            t(
+                                              'integrations:' +
+                                                mi.monitoring.detailedState
+                                                  .value
+                                            )
+                                          }
+                                          monitoringCurrentStep={
+                                            mi.monitoring &&
+                                            mi.monitoring.detailedState
+                                              .currentStep
+                                          }
+                                          monitoringTotalSteps={
+                                            mi.monitoring &&
+                                            mi.monitoring.detailedState
+                                              .totalSteps
+                                          }
+                                          monitoringLogUrl={getPodLogUrl(
+                                            config,
+                                            mi.monitoring
+                                          )}
+                                          key={index}
+                                          i18nConfigurationRequired={t(
+                                            'integrations:ConfigurationRequired'
+                                          )}
+                                          i18nError={t('shared:Error')}
+                                          i18nPublished={t('shared:Published')}
+                                          i18nUnpublished={t(
+                                            'shared:Unpublished'
+                                          )}
+                                          i18nProgressPending={t(
+                                            'shared:Pending'
+                                          )}
+                                          i18nProgressStarting={t(
+                                            'integrations:progressStarting'
+                                          )}
+                                          i18nProgressStopping={t(
+                                            'integrations:progressStopping'
+                                          )}
+                                          i18nLogUrlText={t('shared:viewLogs')}
+                                        />
+                                      )
                                     )}
-                                  />
-                                </ConnectionsGridCell>
-                              ))
-                            }
-                          </WithLoader>
-                        </ConnectionsGrid>
-                      }
-                      i18nConnections={t('shared:Connections')}
-                      i18nLinkCreateConnection={t(
-                        'shared:linkCreateConnection'
+                                  </IntegrationsList>
+                                )}
+                              </WithLoader>
+                            </TopIntegrationsCard>
+                          }
+                          integrationBoard={
+                            <IntegrationBoard
+                              runningIntegrations={
+                                integrationStatesCount.Published
+                              }
+                              pendingIntegrations={
+                                integrationStatesCount.Pending
+                              }
+                              stoppedIntegrations={
+                                integrationStatesCount.Unpublished
+                              }
+                              i18nTitle={t('titleIntegrationBoard')}
+                              i18nIntegrationStatePending={t(
+                                'integrationStatePending'
+                              )}
+                              i18nIntegrationStateRunning={t(
+                                'integrationStateRunning'
+                              )}
+                              i18nIntegrationStateStopped={t(
+                                'integrationStateStopped'
+                              )}
+                              i18nIntegrations={t('shared:Integrations')}
+                              i18nTotal={t('shared:Total')}
+                            />
+                          }
+                          integrationUpdates={
+                            <RecentUpdatesCard
+                              i18nTitle={t('titleIntegrationUpdates')}
+                            >
+                              <WithLoader
+                                error={false}
+                                loading={!hasIntegrations}
+                                loaderChildren={<RecentUpdatesSkeleton />}
+                                errorChildren={<div>TODO</div>}
+                              >
+                                {() =>
+                                  recentlyUpdatedIntegrations.map(i => (
+                                    <Grid.Row key={i.id}>
+                                      <Grid.Col sm={5}>{i.name}</Grid.Col>
+                                      <Grid.Col sm={3}>
+                                        <IntegrationStatus
+                                          currentState={i.currentState}
+                                          i18nError={t('shared:Error')}
+                                          i18nPublished={t('shared:Published')}
+                                          i18nUnpublished={t(
+                                            'shared:Unpublished'
+                                          )}
+                                        />
+                                      </Grid.Col>
+                                      <Grid.Col sm={4}>
+                                        {new Date(
+                                          i.updatedAt! || i.createdAt!
+                                        ).toLocaleString()}
+                                      </Grid.Col>
+                                    </Grid.Row>
+                                  ))
+                                }
+                              </WithLoader>
+                            </RecentUpdatesCard>
+                          }
+                          connections={
+                            <ConnectionsGrid>
+                              <WithLoader
+                                error={false}
+                                loading={!hasConnections}
+                                loaderChildren={
+                                  <>
+                                    {new Array(5).fill(0).map((_, index) => (
+                                      <ConnectionsGridCell key={index}>
+                                        <ConnectionSkeleton />
+                                      </ConnectionsGridCell>
+                                    ))}
+                                  </>
+                                }
+                                errorChildren={<div>TODO</div>}
+                              >
+                                {() =>
+                                  connectionsData.items.map((c, index) => (
+                                    <ConnectionsGridCell key={index}>
+                                      <ConnectionCard
+                                        name={c.name}
+                                        description={c.description || ''}
+                                        icon={getConnectionIcon(
+                                          c,
+                                          process.env.PUBLIC_URL
+                                        )}
+                                      />
+                                    </ConnectionsGridCell>
+                                  ))
+                                }
+                              </WithLoader>
+                            </ConnectionsGrid>
+                          }
+                          i18nConnections={t('shared:Connections')}
+                          i18nLinkCreateConnection={t(
+                            'shared:linkCreateConnection'
+                          )}
+                          i18nLinkCreateIntegration={t(
+                            'shared:linkCreateIntegration'
+                          )}
+                          i18nLinkToConnections={t('linkToConnections')}
+                          i18nLinkToIntegrations={t('linkToIntegrations')}
+                          i18nTitle={t('title')}
+                          i18nTitleIntegrationUpdates={t(
+                            'titleIntegrationUpdates'
+                          )}
+                        />
                       )}
-                      i18nLinkCreateIntegration={t(
-                        'shared:linkCreateIntegration'
-                      )}
-                      i18nLinkToConnections={t('linkToConnections')}
-                      i18nLinkToIntegrations={t('linkToIntegrations')}
-                      i18nTitle={t('title')}
-                      i18nTitleIntegrationUpdates={t('titleIntegrationUpdates')}
-                    />
+                    </NamespacesConsumer>
                   )}
-                </NamespacesConsumer>
+                </AppContext.Consumer>
               );
             }}
           </WithConnections>

--- a/syndesis/src/modules/integrations/locales/integrations-translations.en.json
+++ b/syndesis/src/modules/integrations/locales/integrations-translations.en.json
@@ -1,6 +1,10 @@
 {
   "ConfigurationRequired": "Configuration Required",
   "filterByConnectionPlaceholder": "Filter by Connection",
-  "progressStarting": "Di Partenza...",
-  "progressStopping": "Sosta..."
+  "progressStarting": "Starting...",
+  "progressStopping": "Stopping...",
+  "ASSEMBLING": "Assembling",
+  "BUILDING": "Building",
+  "DEPLOYING": "Deploying",
+  "STARTING": "Starting"
 }

--- a/syndesis/src/modules/integrations/locales/integrations-translations.it.json
+++ b/syndesis/src/modules/integrations/locales/integrations-translations.it.json
@@ -1,6 +1,10 @@
 {
   "ConfigurationRequired": "Configurazione Richiesta",
   "filterByConnectionPlaceholder": "Filtra per Nome",
-  "progressStarting": "Starting...",
-  "progressStopping": "Stopping..."
+  "progressStarting": "Di Partenza...",
+  "progressStopping": "Sosta...",
+  "ASSEMBLING": "Assemblaggio",
+  "BUILDING": "Costruzione",
+  "DEPLOYING": "La Diffusione",
+  "STARTING": "Di Partenza"
 }


### PR DESCRIPTION
fixes #37 - adds storybooks and tests for IntegrationProgress and IntegrationStatusDetail, and adds the log link property to both.

Also tweaks how the detailed status is fetched from the server it'll be driven by integration deployment changes vs polling.

TODO
* feedback?
* ~~rebase to pick up i18n changes~~
* ~~More manual testing with the backend to see how the detailed status works in the integration list~~
* ~~Calculate the log link somewhere and pass it in so it works~~