### PR TITLE
feat: add an auto-form package to generate forms using Formik; fixes #3

### DIFF
--- a/packages/auto-form/.storybook/StoryHelper.css
+++ b/packages/auto-form/.storybook/StoryHelper.css
@@ -1,0 +1,19 @@
+@import url('~patternfly/dist/css/patternfly.css');
+@import url('~patternfly/dist/css/patternfly-additions.css');
+@import url('~patternfly-react/dist/css/patternfly-react.css');
+
+html,
+body,
+#root {
+  height: 100%;
+}
+
+#root {
+  padding: 2em;
+}
+
+.test-area {
+  align-items: center;
+  display: flex;
+  height: 100%;
+}

--- a/packages/auto-form/.storybook/StoryHelper.tsx
+++ b/packages/auto-form/.storybook/StoryHelper.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react';
+import './StoryHelper.css';
+
+export const StoryHelper: React.SFC = ({ children }) => (
+  <div className="test-area">
+    <div className={'container-fluid'}>{children}</div>
+  </div>
+);

--- a/packages/auto-form/.storybook/addons.js
+++ b/packages/auto-form/.storybook/addons.js
@@ -1,0 +1,4 @@
+import '@storybook/addon-a11y/register';
+import '@storybook/addon-knobs/register';
+import '@storybook/addon-options/register';
+import '@storybook/addon-actions/register';

--- a/packages/auto-form/.storybook/config.js
+++ b/packages/auto-form/.storybook/config.js
@@ -1,0 +1,100 @@
+import { addDecorator, configure } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+import { checkA11y } from '@storybook/addon-a11y';
+import { withKnobs } from '@storybook/addon-knobs';
+import { withOptions } from '@storybook/addon-options';
+import * as React from 'react';
+
+const req = require.context('../stories', true, /\.stories\.tsx$/);
+
+function loadStories() {
+  req.keys().forEach(filename => req(filename));
+}
+
+addDecorator(
+  withOptions({
+    /**
+     * name to display in the top left corner
+     * @type {String}
+     */
+    name: '@syndesis/ui',
+    /**
+     * URL for name in top left corner to link to
+     * @type {String}
+     */
+    url: '#',
+    /**
+     * show story component as full screen
+     * @type {Boolean}
+     */
+    goFullScreen: false,
+    /**
+     * display panel that shows a list of stories
+     * @type {Boolean}
+     */
+    showStoriesPanel: true,
+    /**
+     * display panel that shows addon configurations
+     * @type {Boolean}
+     */
+    showAddonPanel: true,
+    /**
+     * display floating search box to search through stories
+     * @type {Boolean}
+     */
+    showSearchBox: false,
+    /**
+     * show addon panel as a vertical panel on the right
+     * @type {Boolean}
+     */
+    addonPanelInRight: false,
+    /**
+     * sorts stories
+     * @type {Boolean}
+     */
+    sortStoriesByKind: false,
+    /**
+     * regex for finding the hierarchy separator
+     * @example:
+     *   null - turn off hierarchy
+     *   /\// - split by `/`
+     *   /\./ - split by `.`
+     *   /\/|\./ - split by `/` or `.`
+     * @type {Regex}
+     */
+    hierarchySeparator: null,
+    /**
+     * regex for finding the hierarchy root separator
+     * @example:
+     *   null - turn off multiple hierarchy roots
+     *   /\|/ - split by `|`
+     * @type {Regex}
+     */
+    hierarchyRootSeparator: null,
+    /**
+     * sidebar tree animations
+     * @type {Boolean}
+     */
+    sidebarAnimations: true,
+    /**
+     * id to select an addon panel
+     * @type {String}
+     */
+    selectedAddonPanel: undefined, // The order of addons in the "Addon panel" is the same as you import them in 'addons.js'. The first panel will be opened by default as you run Storybook
+    /**
+     * enable/disable shortcuts
+     * @type {Boolean}
+     */
+    enableShortcuts: false, // true by default
+  })
+);
+addDecorator(
+  withInfo({
+    inline: true,
+    header: false,
+    maxPropsIntoLine: 1,
+  })
+);
+addDecorator(checkA11y);
+addDecorator(withKnobs);
+configure(loadStories, module);

--- a/packages/auto-form/.storybook/webpack.config.js
+++ b/packages/auto-form/.storybook/webpack.config.js
@@ -1,0 +1,15 @@
+module.exports = (storybookBaseConfig, configType, defaultConfig) => {
+  defaultConfig.module.rules.push({
+    test: /\.tsx?$/,
+    exclude: /node_modules/,
+    use: [
+      'awesome-typescript-loader?configFileName=tsconfig.storybook.json',
+      'react-docgen-typescript-loader',
+    ],
+  });
+  defaultConfig.resolve.extensions = ['.ts', '.tsx', '.js', '.jsx'];
+  defaultConfig.node = {
+    fs: 'empty',
+  };
+  return defaultConfig;
+};

--- a/packages/auto-form/package.json
+++ b/packages/auto-form/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@syndesis/auto-form",
+  "version": "0.1.0",
+  "main": "dist/auto-form.js",
+  "umd:main": "dist/auto-form.umd.js",
+  "typings": "dist/auto-form/src/index.d.ts",
+  "source": "src/index.ts",
+  "files": [
+    "dist"
+  ],
+  "license": "MIT",
+  "devDependencies": {
+    "@babel/core": "^7.1.5",
+    "@storybook/addon-info": "^4.0.4",
+    "@storybook/addon-options": "^4.0.4",
+    "@storybook/react": "^4.0.4",
+    "@types/expect": "^1.20.3",
+    "@types/jest": "^23.3.9",
+    "@types/patternfly-react": "*",
+    "@types/react": "^16.4.18",
+    "@types/react-dom": "^16.0.9",
+    "awesome-typescript-loader": "^5.2.1",
+    "expect": "^23.6.0",
+    "jest": "^23.6.0",
+    "jest-cli": "^23.6.0",
+    "jest-dom": "^2.1.1",
+    "microbundle": "^0.7.0",
+    "react": "^16.6.0",
+    "react-docgen-typescript-loader": "^3.0.0",
+    "react-dom": "^16.6.0",
+    "react-testing-library": "^5.2.3",
+    "rimraf": "^2.6.2",
+    "ts-jest": "^23.10.4",
+    "tslib": "^1.9.3",
+    "tslint": "^5.11.0",
+    "tslint-config-prettier": "^1.16.0",
+    "tslint-react": "^3.6.0",
+    "typescript": "^3.1.6"
+  },
+  "scripts": {
+    "lint": "tslint -c ../../tslint.json --project .",
+    "test": "jest",
+    "test:watch": "yarn run test --watch",
+    "prebuild": "rimraf dist",
+    "build": "microbundle --no-compress",
+    "dev": "microbundle watch --no-compress",
+    "storybook": "start-storybook -p 9001"
+  },
+  "peerDependencies": {
+    "react": "^16.6.0",
+    "react-dom": "^16.6.0",
+    "react-router": "^4.3.1",
+    "react-router-dom": "^4.3.1",
+    "typescript": "^3.1.6"
+  },
+  "jest": {
+    "setupTestFrameworkScriptFile": "<rootDir>/../.jest/setup.ts",
+    "preset": "ts-jest",
+    "moduleNameMapper": {
+      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/../.jest/fileMock.js",
+      "\\.(css|less)$": "<rootDir>/../.jest/styleMock.js"
+    },
+    "globals": {
+      "ts-jest": {
+        "tsConfig": "tsconfig.storybook.json"
+      }
+    }
+  },
+  "dependencies": {
+    "@syndesis/models": "*",
+    "@syndesis/ui": "*",
+    "formik": "^1.3.2"
+  }
+}

--- a/packages/auto-form/src/AutoForm.tsx
+++ b/packages/auto-form/src/AutoForm.tsx
@@ -1,0 +1,92 @@
+import { Formik } from 'formik';
+import * as React from 'react';
+import { FormBuilder } from './FormBuilder';
+import { IFormDefinition, IFormErrors, IFormValue } from './models';
+
+export interface IAutoFormProps<T extends object> {
+  /**
+   * A map of configuration properties as returned by the Syndesis API
+   */
+  definition: IFormDefinition;
+  /**
+   * The initial value that should be set on the form
+   */
+  initialValue?: T;
+  /**
+   * String to be displayed when a required field isn't set
+   */
+  i18nRequiredProperty: string;
+  /**
+   * Callback function that will be called when the form is submitted
+   */
+  onSave: (value?: T) => void;
+  /**
+   * Validation function called whenever a change or blur event occurs on the form
+   */
+  validate?: (value: T | any) => IFormErrors | Promise<any> | undefined;
+  /**
+   * Child component that will receive the form fields and submit handler
+   */
+  children: (state: IAutoFormState) => any;
+}
+
+export interface IAutoFormState {
+  /**
+   * Fragment containing all of the form fields
+   */
+  fields: JSX.Element;
+  /**
+   * Function to trigger a form submit which will then trigger onSave
+   */
+  handleSubmit: (e?: any) => void;
+}
+
+export class AutoForm<T extends object = IFormValue> extends React.Component<
+  IAutoFormProps<T>,
+  IAutoFormState
+> {
+  public render() {
+    return (
+      <React.Fragment>
+        <FormBuilder
+          definition={this.props.definition}
+          initialValue={this.props.initialValue || {}}
+          onSave={this.props.onSave}
+          i18nRequiredProperty={this.props.i18nRequiredProperty}
+        >
+          {({ initialValue, fields, onSave, getField }) => (
+            <Formik
+              initialValues={initialValue}
+              onSubmit={onSave}
+              validate={this.props.validate}
+            >
+              {({ handleSubmit, values, touched, errors }) => (
+                <form
+                  className="form-horizontal required-pf"
+                  role="form"
+                  onSubmit={handleSubmit}
+                >
+                  {this.props.children({
+                    fields: (
+                      <React.Fragment>
+                        {fields.map(property =>
+                          getField({
+                            errors,
+                            property,
+                            touched,
+                            value: (values || {})[property.name],
+                          })
+                        )}
+                      </React.Fragment>
+                    ),
+                    handleSubmit,
+                  })}
+                </form>
+              )}
+            </Formik>
+          )}
+        </FormBuilder>
+      </React.Fragment>
+    );
+  }
+}

--- a/packages/auto-form/src/FormBuilder.tsx
+++ b/packages/auto-form/src/FormBuilder.tsx
@@ -1,0 +1,186 @@
+import { IConfigurationProperty } from '@syndesis/models';
+import { Field } from 'formik';
+import * as React from 'react';
+import { IFormDefinition, IFormValue } from './models';
+import {
+  FormCheckboxComponent,
+  FormHiddenComponent,
+  FormInputComponent,
+  FormSelectComponent,
+  FormTextAreaComponent,
+} from './widgets';
+
+export interface INamedConfigurationProperty extends IConfigurationProperty {
+  name: string;
+}
+
+export interface IRenderFieldProps {
+  property: INamedConfigurationProperty;
+  value: any;
+  [name: string]: any;
+}
+
+export interface IFormBuilderProps<T> {
+  definition: IFormDefinition;
+  initialValue: T;
+  i18nRequiredProperty: string;
+  onSave: (value?: T | any) => void;
+  children(props: IFormBuilderState<T>): any;
+}
+
+export interface IFormBuilderState<T> {
+  fields: INamedConfigurationProperty[];
+  getField: (props: IRenderFieldProps) => any;
+  initialValue?: T;
+  onSave: (value?: T) => void;
+}
+
+export class FormBuilder<T extends object = IFormValue> extends React.Component<
+  IFormBuilderProps<T>,
+  IFormBuilderState<T>
+> {
+  /**
+   * Converts a property configuration to some kind of input field
+   * @param props
+   */
+  public getField = (props: IRenderFieldProps): any => {
+    // Massage the value in the definition to an input type
+    const type = this.massageType(props.property);
+    const componentTypemaps = {
+      checkbox: FormCheckboxComponent,
+      hidden: FormHiddenComponent,
+      select: FormSelectComponent,
+      textarea: FormTextAreaComponent,
+    };
+    const validate = (value: any) => {
+      if (props.property.required && !value) {
+        return this.props.i18nRequiredProperty;
+      }
+      return undefined;
+    };
+    return (
+      <Field
+        key={props.property.name}
+        name={props.property.name}
+        type={type}
+        validate={validate}
+        {...props}
+        component={componentTypemaps[type] || FormInputComponent}
+      />
+    );
+  };
+
+  public render() {
+    const fields = this.enrichAndOrderProperties(this.props.definition);
+    const massagedValue = this.sanitizeValues(
+      this.props.definition,
+      this.props.initialValue
+    );
+    return this.props.children({
+      fields,
+      getField: this.getField,
+      initialValue: massagedValue,
+      onSave: this.props.onSave,
+    });
+  }
+
+  /**
+   * Ensure that the input values match the property definitions
+   */
+  private sanitizeValues(definition: IFormDefinition, initialValue: any) {
+    return Object.keys(definition).reduce((result, key): any => {
+      const prop = definition[key];
+      let value = this.massageValue(prop, initialValue[key]);
+      if (value == null) {
+        value = this.massageValue(prop, prop.defaultValue);
+      }
+      return { ...result, [key]: value };
+    }, {});
+  }
+
+  /**
+   * Add the 'name' field from the property ID and sort them by the 'order' property
+   */
+  private enrichAndOrderProperties(definition: IFormDefinition) {
+    return Object.keys(definition)
+      .map(key => ({
+        name: key,
+        required: this.massageRequired(definition[key]),
+        type: this.massageType(definition[key]),
+        ...definition[key],
+      }))
+      .sort((a, b) => {
+        const aOrder = (a.order || 0) as number;
+        const bOrder = (b.order || 0) as number;
+        return aOrder - bOrder;
+      });
+  }
+
+  /**
+   * Converts various values passed into the property type to known input types
+   *
+   * @param property
+   */
+  private massageType(property: IConfigurationProperty) {
+    let type = property.type || 'text';
+    switch (type) {
+      case 'int':
+      case 'integer':
+      case 'long':
+        type = 'number';
+        break;
+      case 'string':
+        type = 'text';
+        break;
+      case 'boolean':
+        type = 'checkbox';
+    }
+    if (property.enum && property.enum.length) {
+      type = 'select';
+    }
+    if (property.secret) {
+      type = 'password';
+    }
+    return type;
+  }
+
+  /**
+   * Ensure that the 'required' property is false for checkboxes and hidden fields
+   *
+   * This is a candidate for removal in the future, as it's a workaround
+   *
+   * @param property
+   */
+  private massageRequired(property: IConfigurationProperty): any {
+    switch (property.type) {
+      case 'boolean':
+      case 'checkbox':
+      case 'hidden':
+        return false;
+      default:
+        return property.required;
+    }
+  }
+
+  /**
+   * Converts the given value from a string to the type defined in the property definition
+   *
+   * This is a candidate for removal as it's a workaround
+   *
+   * @param property
+   * @param value
+   */
+  private massageValue(property: IConfigurationProperty, value?: string) {
+    if (value === undefined || value === null) {
+      return value;
+    }
+    switch (property.type) {
+      case 'number':
+        return parseInt(value, 10);
+      case 'checkbox':
+        return String(value).toLocaleLowerCase() === 'true';
+      default:
+        return value;
+    }
+  }
+}

--- a/packages/auto-form/src/index.ts
+++ b/packages/auto-form/src/index.ts
@@ -1,0 +1,2 @@
+export * from './AutoForm';
+export * from './models';

--- a/packages/auto-form/src/models.ts
+++ b/packages/auto-form/src/models.ts
@@ -1,0 +1,12 @@
+import { IConfigurationProperty } from '@syndesis/models';
+
+export interface IFormDefinition {
+  [name: string]: IConfigurationProperty;
+}
+export interface IFormValue {
+  [name: string]: any;
+}
+
+export interface IFormErrors {
+  [name: string]: string;
+}

--- a/packages/auto-form/src/widgets/FormCheckboxComponent.tsx
+++ b/packages/auto-form/src/widgets/FormCheckboxComponent.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+
+export const FormCheckboxComponent = ({
+  field,
+  type,
+  form: { touched, errors },
+  ...props
+}: {
+  [name: string]: any;
+}) => (
+  // TODO replace with PF3/PF4 widget
+  <div className="form-group">
+    <label className="col-sm-2 control-label" htmlFor={field.name}>
+      {props.property.displayName}
+    </label>
+    <div className="col-sm-10">
+      <input
+        type={type}
+        id={field.name}
+        data-testid={field.name}
+        {...field}
+        checked={field.value}
+      />
+      {touched[field.name] && errors[field.name] && (
+        <div className="error">{errors[field.name]}</div>
+      )}
+    </div>
+  </div>
+);

--- a/packages/auto-form/src/widgets/FormHiddenComponent.tsx
+++ b/packages/auto-form/src/widgets/FormHiddenComponent.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+export const FormHiddenComponent = ({
+  field,
+  type,
+  form: { touched, errors },
+  ...props
+}: {
+  [name: string]: any;
+}) => (
+  // TODO replace with PF3/PF4 widget
+  <div>
+    <input type={type} id={field.name} data-testid={field.name} {...field} />
+    {touched[field.name] && errors[field.name] && (
+      <div className="error">{errors[field.name]}</div>
+    )}
+  </div>
+);

--- a/packages/auto-form/src/widgets/FormInputComponent.tsx
+++ b/packages/auto-form/src/widgets/FormInputComponent.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+
+export const FormInputComponent = ({
+  field,
+  type,
+  form: { touched, errors },
+  ...props
+}: {
+  [name: string]: any;
+}) => (
+  // TODO replace with PF3/PF4 widget
+  <div className="form-group">
+    <label className="col-sm-2 control-label" htmlFor={field.name}>
+      {props.property.displayName}
+    </label>
+    <div className="col-sm-10">
+      <input type={type} id={field.name} data-testid={field.name} {...field} />
+      {touched[field.name] && errors[field.name] && (
+        <div className="error">{errors[field.name]}</div>
+      )}
+    </div>
+  </div>
+);

--- a/packages/auto-form/src/widgets/FormSelectComponent.tsx
+++ b/packages/auto-form/src/widgets/FormSelectComponent.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+
+export const FormSelectComponent = ({
+  field,
+  form: { touched, errors },
+  ...props
+}: {
+  [name: string]: any;
+}) => (
+  // TODO replace with PF3/PF4 widget
+  <div className="form-group">
+    <label className="col-sm-2 control-label" htmlFor={field.name}>
+      {props.property.displayName}
+    </label>
+    <div className="col-sm-10">
+      <select id={field.name} data-testid={field.name} {...field}>
+        {props.property.enum.map((opt: any) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+      {touched[field.name] && errors[field.name] && (
+        <div className="error">{errors[field.name]}</div>
+      )}
+    </div>
+  </div>
+);

--- a/packages/auto-form/src/widgets/FormTextAreaComponent.tsx
+++ b/packages/auto-form/src/widgets/FormTextAreaComponent.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+export const FormTextAreaComponent = ({
+  field,
+  form: { touched, errors },
+  ...props
+}: {
+  [name: string]: any;
+}) => (
+  // TODO replace with PF3/PF4 widget
+  <div className="form-group">
+    <label className="col-sm-2 control-label" htmlFor={field.name}>
+      {props.property.displayName}
+    </label>
+    <div className="col-sm-10">
+      <textarea id={field.name} data-testid={field.name} {...field} />
+      {touched[field.name] && errors[field.name] && (
+        <div className="error">{errors[field.name]}</div>
+      )}
+    </div>
+  </div>
+);

--- a/packages/auto-form/src/widgets/index.ts
+++ b/packages/auto-form/src/widgets/index.ts
@@ -1,0 +1,5 @@
+export * from './FormInputComponent';
+export * from './FormSelectComponent';
+export * from './FormTextAreaComponent';
+export * from './FormCheckboxComponent';
+export * from './FormHiddenComponent';

--- a/packages/auto-form/stories/AutoForm.stories.tsx
+++ b/packages/auto-form/stories/AutoForm.stories.tsx
@@ -1,0 +1,200 @@
+import { object, text } from '@storybook/addon-knobs';
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { StoryHelper } from '../.storybook/StoryHelper';
+import { AutoForm, IFormDefinition } from '../src';
+
+const stories = storiesOf('Components', module);
+
+const formDefinition = {
+  brokerCertificate: {
+    componentProperty: true,
+    deprecated: false,
+    description: 'AMQ Broker X.509 PEM Certificate',
+    displayName: 'Broker Certificate',
+    group: 'security',
+    javaType: 'java.lang.String',
+    kind: 'property',
+    label: 'common,security',
+    order: 6,
+    relation: [
+      {
+        action: 'ENABLE',
+        when: [
+          {
+            id: 'skipCertificateCheck',
+            value: 'false',
+          },
+        ],
+      },
+    ],
+    required: false,
+    secret: false,
+    type: 'textarea',
+  },
+  brokerUrl: {
+    componentProperty: true,
+    deprecated: false,
+    displayName: 'Broker URL',
+    group: 'common',
+    javaType: 'java.lang.String',
+    kind: 'property',
+    label: 'common',
+    labelHint: 'Location to send data to or obtain data from.',
+    order: 0,
+    placeholder: 'for example, failover://ssl://{BROKER-HOST}:{BROKER-PORT}',
+    required: true,
+    secret: false,
+    type: 'string',
+  },
+  clientID: {
+    componentProperty: true,
+    deprecated: false,
+    displayName: 'Client ID',
+    group: 'security',
+    javaType: 'java.lang.String',
+    kind: 'property',
+    label: 'common,security',
+    labelHint:
+      'Required for connections to close and reopen without missing messages. Connection destination must be a topic.',
+    order: 4,
+    required: false,
+    secret: false,
+    type: 'string',
+  },
+  clientNumber: {
+    componentProperty: true,
+    defaultValue: '5',
+    deprecated: false,
+    displayName: 'Client Number',
+    group: 'security',
+    javaType: 'java.lang.String',
+    kind: 'property',
+    label: 'common,security',
+    labelHint:
+      'Required for connections to close and reopen without missing messages. Connection destination must be a topic.',
+    order: 4,
+    required: false,
+    secret: false,
+    type: 'number',
+  },
+  password: {
+    componentProperty: true,
+    deprecated: false,
+    displayName: 'Password',
+    group: 'security',
+    javaType: 'java.lang.String',
+    kind: 'property',
+    label: 'common,security',
+    labelHint: 'Password for the specified user account.',
+    order: 1,
+    required: false,
+    secret: true,
+    type: 'string',
+  },
+  showAll: {
+    componentProperty: false,
+    defaultValue: 'true',
+    deprecated: false,
+    description: 'whether or not to log everything (very verbose).',
+    displayName: 'Log everything',
+    javaType: 'boolean',
+    kind: 'parameter',
+    order: 2,
+    required: false,
+    secret: false,
+    type: 'boolean',
+  },
+  skipCertificateCheck: {
+    componentProperty: true,
+    defaultValue: 'false',
+    deprecated: false,
+    displayName: 'Check Certificates',
+    enum: [
+      {
+        label: 'Disable',
+        value: 'true',
+      },
+      {
+        label: 'Enable',
+        value: 'false',
+      },
+    ],
+    group: 'security',
+    javaType: 'java.lang.String',
+    kind: 'property',
+    label: 'common,security',
+    labelHint:
+      'Ensure certificate checks are enabled for secure production environments. Disable for convenience in only development environments.',
+    order: 5,
+    required: false,
+    secret: false,
+    type: 'string',
+  },
+  username: {
+    componentProperty: true,
+    deprecated: false,
+    displayName: 'User Name',
+    group: 'security',
+    javaType: 'java.lang.String',
+    kind: 'property',
+    label: 'common,security',
+    labelHint: 'Access the broker with this user’s authorization credentials.',
+    order: 2,
+    required: false,
+    secret: false,
+    type: 'hidden',
+  },
+} as IFormDefinition;
+
+export const initialValue = {
+  brokerUrl: 'tcp://blah',
+  password:
+    '»ENC:c4b1c3818185a78d61f31d3b2bcba791d0e1dc6c5e691f4bf25f8513d6ee999b',
+  skipCertificateCheck: 'false',
+  username: 'blah',
+};
+
+stories
+  .addDecorator(story => <StoryHelper>{story()}</StoryHelper>)
+  .add('AutoForm', () => {
+    const onSave = v => {
+      alert('Got value: ' + JSON.stringify(v, undefined, 2));
+    };
+    const validate = v => {
+      const errors: any = {};
+      if (v.clientID === 'foo') {
+        errors.clientID = 'Client ID cannot be set to "foo"';
+      }
+      return errors;
+    };
+    return (
+      <AutoForm
+        definition={object('definition', formDefinition)}
+        initialValue={object('initialValue', initialValue)}
+        i18nRequiredProperty={text(
+          'i18nRequiredProperty',
+          'This property is required'
+        )}
+        validate={validate}
+        onSave={onSave}
+      >
+        {({ fields, handleSubmit }) => (
+          <React.Fragment>
+            <p className="fields-status-pf">
+              The fields marked with <span className="required-pf">*</span> are
+              required.
+            </p>
+            {fields}
+            <button
+              type="button"
+              className="btn btn-primary"
+              onClick={handleSubmit}
+            >
+              Submit
+            </button>
+          </React.Fragment>
+        )}
+      </AutoForm>
+    );
+  });

--- a/packages/auto-form/tests/AutoForm.spec.tsx
+++ b/packages/auto-form/tests/AutoForm.spec.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { render } from 'react-testing-library';
+import { AutoForm } from '../src';
+
+export default describe('AutoForm', () => {
+  const onSave = () => {
+    // TODO
+  };
+  const testComponent = (
+    <AutoForm
+      definition={{
+        foo: {
+          defaultValue: 'bar',
+          displayName: 'Foo',
+          type: 'text',
+        },
+      }}
+      i18nRequiredProperty={'required'}
+      onSave={onSave}
+    >
+      {({ fields, handleSubmit }) => <React.Fragment>{fields}</React.Fragment>}
+    </AutoForm>
+  );
+
+  it('Should have an input', () => {
+    const { queryByTestId } = render(testComponent);
+    expect(queryByTestId('foo')).toBeDefined();
+  });
+});

--- a/packages/auto-form/tsconfig.json
+++ b/packages/auto-form/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "esnext",
+    "lib": ["es6", "dom"],
+    "sourceMap": true,
+    "allowJs": false,
+    "jsx": "react",
+    "moduleResolution": "node",
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noImplicitAny": true,
+    "importHelpers": true,
+    "strictNullChecks": true,
+    "suppressImplicitAnyIndexErrors": true,
+    "noUnusedLocals": true,
+    "skipLibCheck": false,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "baseUrl": "./",
+  "include": ["src/**/*", "../.jest/**/*"],
+  "exclude": [".storybook", "node_modules", "dist", "stories"]
+}

--- a/packages/auto-form/tsconfig.storybook.json
+++ b/packages/auto-form/tsconfig.storybook.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "noImplicitAny": false,
+    "skipLibCheck": false
+  }
+}

--- a/packages/auto-form/tslint.json
+++ b/packages/auto-form/tslint.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["tslint:recommended", "tslint-react", "tslint-config-prettier"],
+  "linterOptions": {
+    "exclude": ["node_modules/**/*.ts"]
+  }
+}

--- a/packages/models/src/extra.d.ts
+++ b/packages/models/src/extra.d.ts
@@ -1,4 +1,15 @@
-import { IntegrationMetricsSummary, IntegrationOverview } from './models';
+import {
+  ConfigurationProperty,
+  IntegrationMetricsSummary,
+  IntegrationOverview,
+} from './models';
+
+// TODO remove when these values are advertised by the swagger
+export interface IConfigurationProperty extends ConfigurationProperty {
+  componentProperty?: boolean;
+  required?: boolean;
+  secret?: boolean;
+}
 
 export interface IntegrationWithOverview {
   integration: IntegrationOverview;

--- a/syndesis/package.json
+++ b/syndesis/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@craco/craco": "^3.1.0",
     "@syndesis/api": "*",
+    "@syndesis/auto-form": "*",
     "@syndesis/atlasmap-adapter": "*",
     "@syndesis/connector-ftp": "*",
     "@syndesis/models": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5258,7 +5258,7 @@ create-react-class@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-create-react-context@0.2.3, create-react-context@^0.2.1:
+create-react-context@0.2.3, create-react-context@^0.2.1, create-react-context@^0.2.2:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.3.tgz#9ec140a6914a22ef04b8b09b7771de89567cb6f3"
   dependencies:
@@ -5836,7 +5836,7 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
-deepmerge@^2.2.1:
+deepmerge@^2.1.1, deepmerge@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
 
@@ -7260,6 +7260,21 @@ form-data@~2.3.1, form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
+formik@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/formik/-/formik-1.3.2.tgz#f97b9e71084db4a51f7bde798584c094b3696738"
+  integrity sha512-WzKX8MGfSJTBF97oDDeP2meb2/I1bi1dLdkICmUfPB2KJ9mcdBOmsOPY8cE1cfV25ML3DzLomYsUezH+yedpvQ==
+  dependencies:
+    create-react-context "^0.2.2"
+    deepmerge "^2.1.1"
+    hoist-non-react-statics "^2.5.5"
+    lodash.clonedeep "^4.5.0"
+    lodash.topath "4.5.2"
+    prop-types "^15.6.1"
+    react-fast-compare "^1.0.0"
+    tslib "^1.9.3"
+    warning "^3.0.0"
+
 forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
@@ -7990,7 +8005,7 @@ hoist-non-react-statics@3.0.1:
   dependencies:
     react-is "^16.3.2"
 
-hoist-non-react-statics@^2.1.1, hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
+hoist-non-react-statics@^2.1.1, hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0, hoist-non-react-statics@^2.5.5:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
 
@@ -10103,6 +10118,11 @@ lodash.templatesettings@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz#2b4d4e95ba440d915ff08bc899e4553666713316"
   dependencies:
     lodash._reinterpolate "~3.0.0"
+
+lodash.topath@4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/lodash.topath/-/lodash.topath-4.5.2.tgz#3616351f3bba61994a0931989660bd03254fd009"
+  integrity sha1-NhY1Hzu6YZlKCTGYlmC9AyVP0Ak=
 
 lodash.uniq@^4.5.0:
   version "4.5.0"
@@ -13587,6 +13607,11 @@ react-dom@^16.5.2, react-dom@^16.6.0:
 react-error-overlay@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.1.0.tgz#c516995a5652e7bfbed8b497910d5280df74a7e8"
+
+react-fast-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-1.0.0.tgz#813a039155e49b43ceffe99528fe5e9d97a6c938"
+  integrity sha512-dcQpdWr62flXQJuM8/bVEY5/10ad2SYBUafp8H4q4WHR3fTA/MMlp8mpzX12I0CCoEJc1P6QdiMg7U+7lFS6Rw==
 
 react-fast-compare@^2.0.2:
   version "2.0.4"


### PR DESCRIPTION
First spike for #3 

Figured I'd take a poke at using Formik, so with some copypasta to create a new package I threw together @riccardo-forina's suggestions and it didn't destroy the multiverse :-)  The usage is pretty simple:

```
        <AutoForm
          definition={formDefinition}
          initialValues={initialValue}
          onSave={onSave}
        />
```

Where `definition` is the map of `ConfigurationProperty` and `initialValues` would be the usual `configuredProperties` from the backend.

I didn't wind up using the patternfly-react form components to start off with as I wanted to be sure the binding all worked as expected.

Using the AMQ configuration properties and some made-up ones:
![image](https://user-images.githubusercontent.com/351660/49822653-bb353100-fd4b-11e8-8d6d-475cdc39bbe5.png)

Clicking submit after mucking with some values:
![image](https://user-images.githubusercontent.com/351660/49822671-c38d6c00-fd4b-11e8-8426-215b247fb6a7.png)

TODO - some of these it might be better to iterate on
* feedback?
* ~~Support more types (currently select, text and textarea)~~
* ~~Basic validation (i.e. 'required')~~
* ~~Remove submit button from AutoForm component by maybe exposing a `doSubmit()` on the form object~~
* ~~Move UI widgets to the UI and add dependency~~ -> Deferring
* ~~Other TODOs in the code~~
* ~~Proper tests~~ -> Deferring
* ~~[this](https://github.com/syndesisio/syndesis-react-poc/pull/45#discussion_r240158415)~~ -> Deferring