### PR TITLE
feat(checkbox): add support for basic pf3 checkbox

### DIFF
--- a/packages/auto-form/.storybook/config.js
+++ b/packages/auto-form/.storybook/config.js
@@ -1,6 +1,6 @@
 import { addDecorator, configure } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
-import { checkA11y } from '@storybook/addon-a11y';
+// import { checkA11y } from '@storybook/addon-a11y';
 import { withKnobs } from '@storybook/addon-knobs';
 import { withOptions } from '@storybook/addon-options';
 import * as React from 'react';
@@ -95,6 +95,6 @@ addDecorator(
     maxPropsIntoLine: 1,
   })
 );
-addDecorator(checkA11y);
+// addDecorator(checkA11y);
 addDecorator(withKnobs);
 configure(loadStories, module);

--- a/packages/auto-form/package.json
+++ b/packages/auto-form/package.json
@@ -69,6 +69,7 @@
   "dependencies": {
     "@syndesis/models": "*",
     "@syndesis/ui": "*",
-    "formik": "^1.3.2"
+    "formik": "^1.3.2",
+    "patternfly-react": "^2.29.10"
   }
 }

--- a/packages/auto-form/src/FormBuilder.tsx
+++ b/packages/auto-form/src/FormBuilder.tsx
@@ -177,6 +177,7 @@ export class FormBuilder<T> extends React.Component<
     switch (property.type) {
       case 'number':
         return parseInt(value, 10);
+      case 'boolean':
       case 'checkbox':
         return String(value).toLocaleLowerCase() === 'true';
       default:

--- a/packages/auto-form/src/widgets/FormCheckboxComponent.tsx
+++ b/packages/auto-form/src/widgets/FormCheckboxComponent.tsx
@@ -9,19 +9,16 @@ export const FormCheckboxComponent = ({
 }: {
   [name: string]: any;
 }) => (
-    <FormGroup>
-      <Checkbox
-        {...field}
-        id={field.name}
-        checked={field.value}
-        data-testid={field.name}
-        onChange={field.onChange}
-      >
-        {props.property.displayName}
-      </Checkbox>
-      <HelpBlock>{props.property.description}</HelpBlock>
-      {touched[field.name] && errors[field.name] && (
-        <div className="error">{errors[field.name]}</div>
-      )}
-    </FormGroup>
-  );
+  <FormGroup>
+    <Checkbox
+      {...field}
+      id={field.name}
+      checked={field.value}
+      data-testid={field.name}
+      onChange={field.onChange}
+    >
+      {props.property.displayName}
+    </Checkbox>
+    <HelpBlock>{props.property.description}</HelpBlock>
+  </FormGroup>
+);

--- a/packages/auto-form/src/widgets/FormCheckboxComponent.tsx
+++ b/packages/auto-form/src/widgets/FormCheckboxComponent.tsx
@@ -1,3 +1,4 @@
+import { Checkbox, FormGroup, HelpBlock } from 'patternfly-react';
 import * as React from 'react';
 
 export const FormCheckboxComponent = ({
@@ -8,23 +9,19 @@ export const FormCheckboxComponent = ({
 }: {
   [name: string]: any;
 }) => (
-  // TODO replace with PF3/PF4 widget
-  <div className="form-group">
-    <div className="checkbox">
-      <label htmlFor={field.name}>
-        <input
-          type={type}
-          id={field.name}
-          data-testid={field.name}
-          {...field}
-          checked={field.value === 'true'}
-          disabled={isSubmitting}
-        />
+    <FormGroup>
+      <Checkbox
+        {...field}
+        id={field.name}
+        checked={field.value}
+        data-testid={field.name}
+        onChange={field.onChange}
+      >
         {props.property.displayName}
-      </label>
+      </Checkbox>
+      <HelpBlock>{props.property.description}</HelpBlock>
       {touched[field.name] && errors[field.name] && (
         <div className="error">{errors[field.name]}</div>
       )}
-    </div>
-  </div>
-);
+    </FormGroup>
+  );

--- a/packages/auto-form/src/widgets/FormCheckboxComponent.tsx
+++ b/packages/auto-form/src/widgets/FormCheckboxComponent.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 export const FormCheckboxComponent = ({
   field,
   type,
-  form: { touched, errors, isSubmitting },
   ...props
 }: {
   [name: string]: any;

--- a/packages/auto-form/tests/AutoForm.spec.tsx
+++ b/packages/auto-form/tests/AutoForm.spec.tsx
@@ -6,7 +6,7 @@ export default describe('AutoForm', () => {
   const onSave = () => {
     // TODO
   };
-  const testComponent = (
+  const testTextInputComponent = (
     <AutoForm
       definition={{
         foo: {
@@ -23,8 +23,46 @@ export default describe('AutoForm', () => {
     </AutoForm>
   );
 
-  it('Should have an input', () => {
-    const { queryByTestId } = render(testComponent);
-    expect(queryByTestId('foo')).toBeDefined();
+  const testCheckboxComponent = (
+    <AutoForm
+      definition={{
+        showAll: {
+          defaultValue: 'true',
+          description: 'whether or not to log everything (very verbose).',
+          displayName: 'Log everything',
+          type: 'boolean',
+        },
+      }}
+      initialValue={true}
+      i18nRequiredProperty={'required'}
+      onSave={onSave}
+    >
+      {({ fields, handleSubmit }) => <React.Fragment>{fields}</React.Fragment>}
+    </AutoForm>
+  );
+
+  it('Should use the definition key as an id for text input', () => {
+    const { getByTestId } = render(testTextInputComponent);
+    const idValue = Object.keys(testTextInputComponent.props.definition);
+    expect(getByTestId(idValue[0])).toBeDefined();
+  });
+
+  it('Should use the displayName as a label in text input', () => {
+    const { getByLabelText } = render(testTextInputComponent);
+    const displayName = testTextInputComponent.props.definition.foo.displayName;
+    expect(getByLabelText(displayName)).toBeDefined();
+  });
+
+  it('Should use the definition key as an id for checkbox', () => {
+    const { getByTestId } = render(testCheckboxComponent);
+    const idValue = Object.keys(testCheckboxComponent.props.definition);
+    expect(getByTestId(idValue[0])).toBeDefined();
+  });
+
+  it('Should use the displayName as a label in checkbox', () => {
+    const { getByLabelText } = render(testCheckboxComponent);
+    const displayName =
+      testCheckboxComponent.props.definition.showAll.displayName;
+    expect(getByLabelText(displayName)).toBeTruthy();
   });
 });

--- a/packages/auto-form/tests/AutoForm.spec.tsx
+++ b/packages/auto-form/tests/AutoForm.spec.tsx
@@ -33,7 +33,7 @@ export default describe('AutoForm', () => {
           type: 'boolean',
         },
       }}
-      initialValue={true}
+      initialValue={{}}
       i18nRequiredProperty={'required'}
       onSave={onSave}
     >

--- a/yarn.lock
+++ b/yarn.lock
@@ -11912,6 +11912,32 @@ patternfly-react@^2.29.2:
     sortabular "^1.5.1"
     table-resolver "^3.2.0"
 
+patternfly-react@^2.29.10:
+  version "2.29.10"
+  resolved "https://registry.yarnpkg.com/patternfly-react/-/patternfly-react-2.29.10.tgz#09826ca94bcd560ffa80ec4210b62ee42f704ad6"
+  integrity sha512-mQpn+aK96vCFX7OsrNAOyBfZVfB7/Wv9lhQ5e9YurOjeV/gVCxEXDZBA8jdGTh2eHWkTvcr8krNJoPtv3blLow==
+  dependencies:
+    bootstrap-slider-without-jquery "^10.0.0"
+    breakjs "^1.0.0"
+    classnames "^2.2.5"
+    css-element-queries "^1.0.1"
+    lodash "^4.17.11"
+    patternfly "^3.58.0"
+    react-bootstrap "^0.32.1"
+    react-bootstrap-switch "^15.5.3"
+    react-bootstrap-typeahead "^3.1.3"
+    react-c3js "^0.1.20"
+    react-click-outside "^3.0.1"
+    react-collapse "^4.0.3"
+    react-fontawesome "^1.6.1"
+    react-motion "^0.5.2"
+    reactabular-table "^8.14.0"
+    recompose "^0.26.0"
+    uuid "^3.3.2"
+  optionalDependencies:
+    sortabular "^1.5.1"
+    table-resolver "^3.2.0"
+
 patternfly@3.51.2:
   version "3.51.2"
   resolved "https://registry.yarnpkg.com/patternfly/-/patternfly-3.51.2.tgz#6a2cf76377495ebea8f1f17329bcf87e07f2f61a"


### PR DESCRIPTION
This PR teaches auto-form to use the PF3 checkbox.

Step toward resolving https://github.com/syndesisio/syndesis-react-poc/issues/46

add patternfly-react as an auto-form dependency
turn off a11y checks until storybook stops throwing errors
account for checkboxes when massaging values (massageValue in FormBuilder)
use components from patternfly-react to build out the FormCheckboxComponent
improve tests for text input, add new tests for checkbox