### PR TITLE
feat(checkbox): add support for disabled state and storybook

### DIFF
--- a/packages/auto-form/package.json
+++ b/packages/auto-form/package.json
@@ -19,6 +19,7 @@
     "@types/patternfly-react": "*",
     "@types/react": "^16.4.18",
     "@types/react-dom": "^16.0.9",
+    "@types/storybook__react": "^4.0.0",
     "awesome-typescript-loader": "^5.2.1",
     "expect": "^23.6.0",
     "jest": "^23.6.0",

--- a/packages/auto-form/src/widgets/FormCheckboxComponent.tsx
+++ b/packages/auto-form/src/widgets/FormCheckboxComponent.tsx
@@ -3,17 +3,18 @@ import * as React from 'react';
 
 export const FormCheckboxComponent = ({
   field,
-  type,
+  form: { isSubmitting },
   ...props
 }: {
   [name: string]: any;
 }) => (
-  <FormGroup>
+  <FormGroup validationState={props.validationState}>
     <Checkbox
       {...field}
       id={field.name}
       checked={field.value}
       data-testid={field.name}
+      disabled={isSubmitting || props.property.disabled}
       onChange={field.onChange}
     >
       {props.property.displayName}

--- a/packages/auto-form/stories/FormCheckboxComponent.stories.tsx
+++ b/packages/auto-form/stories/FormCheckboxComponent.stories.tsx
@@ -1,0 +1,40 @@
+import { boolean, select } from '@storybook/addon-knobs';
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { FormCheckboxComponent } from '../src/widgets/FormCheckboxComponent';
+
+const stories = storiesOf('Checkbox', module);
+
+export const fieldObj = {
+  name: 'showAll',
+  displayName: 'Log Everything',
+  description: 'whether or not to log everything (very verbose).',
+  value: true,
+  disabled: false,
+  onChange: () => {},
+  validationState: '',
+};
+
+stories.add('FormCheckboxComponent', () => {
+  return (
+    <FormCheckboxComponent
+      field={{
+        name: fieldObj.name,
+        value: boolean('Checked', fieldObj.value),
+        onChange: fieldObj.onChange,
+      }}
+      form={{ isSubmitting: false }}
+      property={{
+        disabled: boolean('Disabled', fieldObj.disabled),
+        displayName: fieldObj.displayName,
+        description: fieldObj.description,
+      }}
+      validationState={select('Validation State', [
+        fieldObj.validationState,
+        'success',
+        'warning',
+        'error',
+      ])}
+    />
+  );
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2551,6 +2551,14 @@
     "@types/react" "*"
     "@types/webpack-env" "*"
 
+"@types/storybook__react@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/storybook__react/-/storybook__react-4.0.0.tgz#52cc452fbab599568d595075a90142ef4a1233f6"
+  integrity sha512-Iq3RX953fqZRwWN3jywm8pUx1/Atev+x/9tF7/2CNA+Ii55sGSJJRWMRthUKQXTa3zOexcvfksfVYdUaIZY91w==
+  dependencies:
+    "@types/react" "*"
+    "@types/webpack-env" "*"
+
 "@types/tapable@1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.2.tgz#e13182e1b69871a422d7863e11a4a6f5b814a4bd"


### PR DESCRIPTION
This PR adds support for disabled and validationState states in checkbox. It also adds a storybook entry that exercises the checkbox properties. 

<img width="659" alt="screen shot 2019-02-12 at 9 02 14 pm" src="https://user-images.githubusercontent.com/5942899/52681344-855a2780-2f09-11e9-9b9e-6dde9a012ee6.png">


add support for disabled state in checkbox
add storybook react types
add storybook entry for checkbox