### PR TITLE
chore(form-controls): more test coverage and types for formcontrols

### DIFF
--- a/packages/auto-form/src/models.ts
+++ b/packages/auto-form/src/models.ts
@@ -10,3 +10,32 @@ export interface IFormValue {
 export interface IFormErrors {
   [name: string]: string;
 }
+
+export interface IFormField {
+  name: string;
+  value?: any;
+  onChange?: () => void;
+}
+
+export interface IFormProperty extends IConfigurationProperty {
+  disabled?: boolean;
+}
+
+export interface IFormikFormProp {
+  dirty?: boolean;
+  errors?: string;
+  isSubmitting?: boolean;
+  isValid?: boolean;
+  isValidating?: boolean;
+  status?: any;
+  touched?: boolean;
+  values?: any;
+}
+
+export interface IFormControl {
+  [name: string]: any;
+  field: IFormField;
+  form: IFormikFormProp;
+  property: IFormProperty;
+  validationState?: string;
+}

--- a/packages/auto-form/src/widgets/FormCheckboxComponent.tsx
+++ b/packages/auto-form/src/widgets/FormCheckboxComponent.tsx
@@ -1,13 +1,12 @@
 import { Checkbox, FormGroup, HelpBlock } from 'patternfly-react';
 import * as React from 'react';
+import { IFormControl } from '../models';
 
 export const FormCheckboxComponent = ({
   field,
   form: { isSubmitting },
   ...props
-}: {
-  [name: string]: any;
-}) => (
+}: IFormControl) => (
   <FormGroup validationState={props.validationState}>
     <Checkbox
       {...field}

--- a/packages/auto-form/src/widgets/FormTextAreaComponent.tsx
+++ b/packages/auto-form/src/widgets/FormTextAreaComponent.tsx
@@ -5,14 +5,13 @@ import {
   HelpBlock,
 } from 'patternfly-react';
 import * as React from 'react';
+import { IFormControl } from '../models';
 
 export const FormTextAreaComponent = ({
   field,
   form: { isSubmitting },
   ...props
-}: {
-  [name: string]: any;
-}) => (
+}: IFormControl) => (
   <FormGroup controlId={field.name} validationState={props.validationState}>
     <ControlLabel>{props.property.displayName}</ControlLabel>
     <FormControl

--- a/packages/auto-form/stories/FormCheckboxComponent.stories.tsx
+++ b/packages/auto-form/stories/FormCheckboxComponent.stories.tsx
@@ -12,7 +12,7 @@ export const fieldObj = {
   value: true,
   disabled: false,
   onChange: () => {},
-  validationState: '',
+  validationState: null,
 };
 
 stories.add('FormCheckboxComponent', () => {

--- a/packages/auto-form/stories/FormTextAreaComponent.stories.tsx
+++ b/packages/auto-form/stories/FormTextAreaComponent.stories.tsx
@@ -12,7 +12,7 @@ export const fieldObj = {
   value: '',
   disabled: false,
   onChange: () => {},
-  validationState: '',
+  validationState: null,
 };
 
 stories.add('FormTextAreaComponent', () => {

--- a/packages/auto-form/tests/FormCheckboxComponent.spec.tsx
+++ b/packages/auto-form/tests/FormCheckboxComponent.spec.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { render } from 'react-testing-library';
+import { FormCheckboxComponent } from '../src/widgets/FormCheckboxComponent';
+
+export default describe('FormCheckboxComponent', () => {
+  const formCheckboxComponent = (
+    <FormCheckboxComponent
+      form={{ isSubmitting: false }}
+      field={{
+        name: 'test01TestCheckbox',
+      }}
+      property={{
+        displayName: 'Test CB Control Label',
+        description: 'Test CB dontrol description',
+      }}
+      validationState="error"
+    />
+  );
+
+  it('Should use the definition key as an id for the checkbox', () => {
+    const { getByTestId } = render(formCheckboxComponent);
+    const idValue = formCheckboxComponent.props.field.name;
+    expect(getByTestId(idValue)).toBeDefined();
+  });
+
+  it('Should use the displayName as a label in the checkbox', () => {
+    const { getByLabelText } = render(formCheckboxComponent);
+    const displayName = formCheckboxComponent.props.property.displayName;
+    expect(getByLabelText(displayName)).toBeTruthy();
+  });
+
+  it('Should contain has-error class when validation state is error', () => {
+    const { container } = render(formCheckboxComponent);
+    const hasErrorClass =
+      container.firstElementChild &&
+      container.firstElementChild.classList.contains('has-error');
+    expect(hasErrorClass).toBe(true);
+  });
+});

--- a/packages/auto-form/tests/FormTextAreaComponent.spec.tsx
+++ b/packages/auto-form/tests/FormTextAreaComponent.spec.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { render } from 'react-testing-library';
+import { FormTextAreaComponent } from '../src/widgets/FormTextAreaComponent';
+
+export default describe('FormTextAreaComponent', () => {
+  const formTextAreaComponent = (
+    <FormTextAreaComponent
+      form={{ isSubmitting: false }}
+      field={{
+        name: 'test01TextArea',
+        value: '',
+        onChange: () => {},
+      }}
+      property={{
+        displayName: 'Test Control Label',
+        description: 'Test Description',
+      }}
+    />
+  );
+
+  it('Should use the definition key as an id for the textarea', () => {
+    const { getByTestId } = render(formTextAreaComponent);
+    const idValue = formTextAreaComponent.props.field.name;
+    expect(getByTestId(idValue)).toBeDefined();
+  });
+
+  it('Should use the displayName as a label in the textarea', () => {
+    const { getByLabelText } = render(formTextAreaComponent);
+    const displayName = formTextAreaComponent.props.property.displayName;
+    expect(getByLabelText(displayName)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
This PR introduces dedicated test suites for checkbox and textarea, and also provides some basic interfaces to make using these components a little easier.

Steps toward resolving https://github.com/syndesisio/syndesis-react-poc/issues/46

add new models to represent form fields
add test suite for textarea and checkbox form component