### PR TITLE
feat(textinput): add support for pf3 text input control

### DIFF
--- a/packages/auto-form/src/models.ts
+++ b/packages/auto-form/src/models.ts
@@ -14,6 +14,9 @@ export interface IFormErrors {
 export interface IFormField {
   name: string;
   value?: any;
+  defaultValue?: any;
+  min?: number;
+  max?: number;
   onChange?: () => void;
 }
 
@@ -33,7 +36,8 @@ export interface IFormikFormProp {
 }
 
 export interface IFormControl {
-  [name: string]: any;
+  name?: string;
+  type?: string;
   field: IFormField;
   form: IFormikFormProp;
   property: IFormProperty;

--- a/packages/auto-form/src/widgets/FormInputComponent.tsx
+++ b/packages/auto-form/src/widgets/FormInputComponent.tsx
@@ -1,28 +1,28 @@
+import {
+  ControlLabel,
+  FormControl,
+  FormGroup,
+  HelpBlock,
+} from 'patternfly-react';
 import * as React from 'react';
+import { IFormControl } from '../models';
 
 export const FormInputComponent = ({
   field,
   type,
   form: { touched, errors, isSubmitting },
   ...props
-}: {
-  [name: string]: any;
-}) => (
-  // TODO replace with PF3/PF4 widget
-  <div className="form-group">
-    <label className="control-label" htmlFor={field.name}>
-      {props.property.displayName}
-    </label>
-    <input
-      type={type}
-      id={field.name}
-      data-testid={field.name}
-      disabled={isSubmitting}
-      className={'form-control'}
+}: IFormControl) => (
+  <FormGroup controlId={field.name} validationState={props.validationState}>
+    <ControlLabel>{props.property.displayName}</ControlLabel>
+    <FormControl
       {...field}
+      data-testid={field.name}
+      disabled={isSubmitting || props.property.disabled}
+      placeholder={props.property.placeholder}
+      type={type || 'text'}
+      onChange={field.onChange}
     />
-    {touched[field.name] && errors[field.name] && (
-      <div className="error">{errors[field.name]}</div>
-    )}
-  </div>
+    <HelpBlock>{props.property.description}</HelpBlock>
+  </FormGroup>
 );

--- a/packages/auto-form/stories/FormCheckboxComponent.stories.tsx
+++ b/packages/auto-form/stories/FormCheckboxComponent.stories.tsx
@@ -1,36 +1,29 @@
-import { boolean, select } from '@storybook/addon-knobs';
+import { boolean, select, text } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 import { FormCheckboxComponent } from '../src/widgets/FormCheckboxComponent';
 
 const stories = storiesOf('Checkbox', module);
 
-export const fieldObj = {
-  name: 'showAll',
-  displayName: 'Log Everything',
-  description: 'whether or not to log everything (very verbose).',
-  value: true,
-  disabled: false,
-  onChange: () => {},
-  validationState: null,
-};
-
-stories.add('FormCheckboxComponent', () => {
+stories.add('Basic Checkbox', () => {
   return (
     <FormCheckboxComponent
       field={{
-        name: fieldObj.name,
-        value: boolean('Checked', fieldObj.value),
-        onChange: fieldObj.onChange,
+        name: 'showAll',
+        value: boolean('Checked', true),
+        onChange: () => {},
       }}
       form={{ isSubmitting: false }}
       property={{
-        disabled: boolean('Disabled', fieldObj.disabled),
-        displayName: fieldObj.displayName,
-        description: fieldObj.description,
+        disabled: boolean('Disabled', false),
+        displayName: text('Label', 'Log Everything'),
+        description: text(
+          'Description',
+          'whether or not to log everything (very verbose).'
+        ),
       }}
       validationState={select('Validation State', [
-        fieldObj.validationState,
+        null,
         'success',
         'warning',
         'error',

--- a/packages/auto-form/stories/FormInputComponent.stories.tsx
+++ b/packages/auto-form/stories/FormInputComponent.stories.tsx
@@ -1,0 +1,91 @@
+import { boolean, number, select, text } from '@storybook/addon-knobs';
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { FormInputComponent } from '../src/widgets/FormInputComponent';
+
+const stories = storiesOf('TextInput', module);
+
+stories.add('Basic Text Input', () => {
+  return (
+    <FormInputComponent
+      type="text"
+      field={{
+        name: 'brokerCertificate',
+        value: text('Value', ''),
+        onChange: () => {},
+      }}
+      form={{
+        isSubmitting: false,
+      }}
+      property={{
+        disabled: boolean('Disabled', false),
+        displayName: text('Display Name', 'Broker URL'),
+        placeholder: text(
+          'Placeholder',
+          'for example, failover://ssl://{BROKER-HOST}:{BROKER-PORT}'
+        ),
+        description: text('Description', 'Enter the fully qualified URL'),
+      }}
+      validationState={select('Validation State', [
+        null,
+        'success',
+        'warning',
+        'error',
+      ])}
+    />
+  );
+});
+
+stories.add('Password Input', () => {
+  return (
+    <FormInputComponent
+      type="password"
+      field={{
+        name: 'passwordInput',
+        value: text('Value', 'secret'),
+        onChange: () => {},
+      }}
+      form={{
+        isSubmitting: false,
+      }}
+      property={{
+        disabled: boolean('Disabled', false),
+        displayName: text('Display Name', 'Password'),
+      }}
+      validationState={select('Validation State', [
+        null,
+        'success',
+        'warning',
+        'error',
+      ])}
+    />
+  );
+});
+
+stories.add('Number Input', () => {
+  return (
+    <FormInputComponent
+      type="number"
+      field={{
+        name: 'numberInput',
+        defaultValue: 2,
+        min: number('Min', 0),
+        max: number('Max', 10),
+        onChange: () => {},
+      }}
+      form={{
+        isSubmitting: false,
+      }}
+      property={{
+        disabled: boolean('Disabled', false),
+        displayName: text('Display Name', 'Client Number'),
+      }}
+      validationState={select('Validation State', [
+        null,
+        'success',
+        'warning',
+        'error',
+      ])}
+    />
+  );
+});

--- a/packages/auto-form/stories/FormTextAreaComponent.stories.tsx
+++ b/packages/auto-form/stories/FormTextAreaComponent.stories.tsx
@@ -5,32 +5,22 @@ import { FormTextAreaComponent } from '../src/widgets/FormTextAreaComponent';
 
 const stories = storiesOf('Textarea', module);
 
-export const fieldObj = {
-  name: 'brokerCertificate',
-  displayName: 'Broker Certificate',
-  description: 'AMQ Broker X.509 PEM Certificate',
-  value: '',
-  disabled: false,
-  onChange: () => {},
-  validationState: null,
-};
-
-stories.add('FormTextAreaComponent', () => {
+stories.add('Basic Textarea', () => {
   return (
     <FormTextAreaComponent
       field={{
-        name: fieldObj.name,
-        value: text('Value', fieldObj.value),
-        onChange: fieldObj.onChange,
+        name: 'brokerCertificate',
+        value: text('Value', ''),
+        onChange: () => {},
       }}
       form={{ isSubmitting: false }}
       property={{
-        disabled: boolean('Disabled', fieldObj.disabled),
-        displayName: fieldObj.displayName,
-        description: fieldObj.description,
+        disabled: boolean('Disabled', false),
+        displayName: text('Label', 'Broker Certificate'),
+        description: text('Description', 'AMQ Broker X.509 PEM Certificate'),
       }}
       validationState={select('Validation State', [
-        fieldObj.validationState,
+        null,
         'success',
         'warning',
         'error',

--- a/packages/auto-form/tests/FormInputComponent.spec.tsx
+++ b/packages/auto-form/tests/FormInputComponent.spec.tsx
@@ -1,0 +1,99 @@
+import * as React from 'react';
+import { render } from 'react-testing-library';
+import { FormInputComponent } from '../src/widgets/FormInputComponent';
+
+export default describe('FormInputComponent', () => {
+  const textInputComponent = (
+    <FormInputComponent
+      form={{ isSubmitting: false }}
+      field={{
+        name: 'testTextInput',
+        value: '',
+        onChange: () => {},
+      }}
+      property={{
+        displayName: 'Test Text Input Control Label',
+        description: 'Test text description',
+      }}
+    />
+  );
+
+  it('Should use the definition key as an id for the textinput', () => {
+    const { getByTestId } = render(textInputComponent);
+    const idValue = textInputComponent.props.field.name;
+    expect(getByTestId(idValue)).toBeDefined();
+  });
+
+  it('Should use the displayName as a label in the textinput', () => {
+    const { getByLabelText } = render(textInputComponent);
+    const displayName = textInputComponent.props.property.displayName;
+    expect(getByLabelText(displayName)).toBeTruthy();
+  });
+
+  const pwdInputComponent = (
+    <FormInputComponent
+      type="password"
+      form={{ isSubmitting: false }}
+      field={{
+        name: 'testPwdInput',
+        value: '',
+        onChange: () => {},
+      }}
+      property={{
+        displayName: 'Test Pwd Input Control Label',
+        description: 'Test password description',
+      }}
+    />
+  );
+
+  it('Should use the definition key as an id for the password input', () => {
+    const { getByTestId } = render(pwdInputComponent);
+    const idValue = pwdInputComponent.props.field.name;
+    expect(getByTestId(idValue)).toBeDefined();
+  });
+
+  it('Should use the displayName as a label in the password input', () => {
+    const { getByLabelText } = render(pwdInputComponent);
+    const displayName = pwdInputComponent.props.property.displayName;
+    expect(getByLabelText(displayName)).toBeTruthy();
+  });
+
+  const numberInputComponent = (
+    <FormInputComponent
+      type="number"
+      form={{ isSubmitting: false }}
+      field={{
+        name: 'testNumInput',
+        defaultValue: 2,
+        min: 0,
+        max: 3,
+        onChange: () => {},
+      }}
+      property={{
+        displayName: 'Test Pwd Input Control Label',
+        description: 'Test password description',
+      }}
+    />
+  );
+
+  it('Should use the definition key as an id for the number input', () => {
+    const { getByTestId } = render(numberInputComponent);
+    const idValue = numberInputComponent.props.field.name;
+    expect(getByTestId(idValue)).toBeDefined();
+  });
+
+  it('Should use the displayName as a label in the number input', () => {
+    const { getByLabelText } = render(numberInputComponent);
+    const displayName = numberInputComponent.props.property.displayName;
+    expect(getByLabelText(displayName)).toBeTruthy();
+  });
+
+  it('Should set the value attr with defaultValue prop value', () => {
+    const { getByTestId } = render(numberInputComponent);
+    const defaultValue = String(numberInputComponent.props.field.defaultValue);
+    const domValueAttr = getByTestId(
+      numberInputComponent.props.field.name
+    ).getAttribute('value');
+    expect(defaultValue).toBe(domValueAttr);
+  });
+});


### PR DESCRIPTION
This PR converts our text input to use components provided by patternfly3. It also adds a corresponding storybook entry as well as basic unit tests.

Steps toward solving https://github.com/syndesisio/syndesis-react-poc/issues/46

<img width="835" alt="screen shot 2019-02-13 at 4 05 03 pm" src="https://user-images.githubusercontent.com/5942899/52743936-319f1b00-2fa9-11e9-8001-db3449bc656b.png">


add pf3 text input
storybooks for text, pwd, and num
add tests
clean up other form control tests