### PR TITLE
feat(select): use pf3 FormControl for select component

### DIFF
--- a/packages/auto-form/src/widgets/FormCheckboxComponent.tsx
+++ b/packages/auto-form/src/widgets/FormCheckboxComponent.tsx
@@ -14,7 +14,6 @@ export const FormCheckboxComponent = ({
       checked={field.value}
       data-testid={field.name}
       disabled={isSubmitting || props.property.disabled}
-      onChange={field.onChange}
     >
       {props.property.displayName}
     </Checkbox>

--- a/packages/auto-form/src/widgets/FormSelectComponent.tsx
+++ b/packages/auto-form/src/widgets/FormSelectComponent.tsx
@@ -1,32 +1,32 @@
+import {
+  ControlLabel,
+  FormControl,
+  FormGroup,
+  HelpBlock,
+} from 'patternfly-react';
 import * as React from 'react';
+import { IFormControl } from '../models';
 
 export const FormSelectComponent = ({
   field,
-  form: { touched, errors, isSubmitting },
+  form: { isSubmitting },
   ...props
-}: {
-  [name: string]: any;
-}) => (
-  // TODO replace with PF3/PF4 widget
-  <div className="form-group">
-    <label className="control-label" htmlFor={field.name}>
-      {props.property.displayName}
-    </label>
-    <select
-      id={field.name}
-      data-testid={field.name}
-      disabled={isSubmitting}
-      className={'form-control'}
+}: IFormControl) => (
+  <FormGroup controlId={field.name} validationState={props.validationState}>
+    <ControlLabel>{props.property.displayName}</ControlLabel>
+    <FormControl
       {...field}
+      data-testid={field.name}
+      disabled={isSubmitting || props.property.disabled}
+      componentClass="select"
     >
-      {props.property.enum.map((opt: any) => (
-        <option key={opt.value} value={opt.value}>
-          {opt.label}
-        </option>
-      ))}
-    </select>
-    {touched[field.name] && errors[field.name] && (
-      <div className="error">{errors[field.name]}</div>
-    )}
-  </div>
+      {props.property.enum &&
+        props.property.enum.map((opt: any) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+    </FormControl>
+    <HelpBlock>{props.property.description}</HelpBlock>
+  </FormGroup>
 );

--- a/packages/auto-form/stories/FormSelectComponent.stories.tsx
+++ b/packages/auto-form/stories/FormSelectComponent.stories.tsx
@@ -1,0 +1,41 @@
+import { boolean, select, object, text } from '@storybook/addon-knobs';
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { FormSelectComponent } from '../src/widgets/FormSelectComponent';
+
+const stories = storiesOf('Select', module);
+
+stories.add('Basic Select', () => {
+  return (
+    <FormSelectComponent
+      field={{
+        name: 'skipCertificateCheck',
+        onChange: () => {
+          console.log('you changed the select value');
+        },
+      }}
+      form={{ isSubmitting: false }}
+      property={{
+        disabled: boolean('Disabled', false),
+        displayName: text('Label', 'Check Certificates'),
+        description: text('Description', ''),
+        enum: object('Values', [
+          {
+            label: 'Disable',
+            value: 'true',
+          },
+          {
+            label: 'Enable',
+            value: 'false',
+          },
+        ]),
+      }}
+      validationState={select('Validation State', [
+        null,
+        'success',
+        'warning',
+        'error',
+      ])}
+    />
+  );
+});

--- a/packages/auto-form/tests/FormSelectComponent.spec.tsx
+++ b/packages/auto-form/tests/FormSelectComponent.spec.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { render } from 'react-testing-library';
+import { FormSelectComponent } from '../src/widgets/FormSelectComponent';
+
+export default describe('FormSelectComponent', () => {
+  const formSelectComponent = (
+    <FormSelectComponent
+      form={{ isSubmitting: false }}
+      field={{
+        name: 'test01Select',
+        value: '',
+        onChange: () => {},
+      }}
+      property={{
+        displayName: 'Test Select Control Label',
+        description: 'Test Select Description',
+      }}
+      validationState="warning"
+    />
+  );
+
+  it('Should use the definition key as an id for the select', () => {
+    const { getByTestId } = render(formSelectComponent);
+    const idValue = formSelectComponent.props.field.name;
+    expect(getByTestId(idValue)).toBeDefined();
+  });
+
+  it('Should use the displayName as a label in the select', () => {
+    const { getByLabelText } = render(formSelectComponent);
+    const displayName = formSelectComponent.props.property.displayName;
+    expect(getByLabelText(displayName)).toBeTruthy();
+  });
+
+  it('Should set the proper css class when validationState prop is warning', () => {
+    const { container } = render(formSelectComponent);
+    const hasWarningClass =
+      container.firstElementChild &&
+      container.firstElementChild.classList.contains('has-warning');
+    expect(hasWarningClass).toBe(true);
+  });
+});


### PR DESCRIPTION
This PR adds the pf3 FormControl as the building block for our select component. Also adds a dedicated storybook entry and corresponding test suite.

I also removed the onChange binding in checkbox component, because it works with or without this. Can add it back if/when we determine it's actually doing something necessary. Will probably become relevant as we begin to add more features to our form components, like validation.

Step toward resolving https://github.com/syndesisio/syndesis-react-poc/issues/46

<img width="669" alt="screen shot 2019-02-14 at 2 40 14 pm" src="https://user-images.githubusercontent.com/5942899/52812902-8d7ba980-3066-11e9-94e7-8db3164e5e4f.png">


add tests
add stories
remove unnecessary onChange binding from checkbox