### PR TITLE
feature(integrationDetailHistoryListView)

### DIFF
--- a/packages/ui/src/Integration/IntegrationDetailHistoryListView.tsx
+++ b/packages/ui/src/Integration/IntegrationDetailHistoryListView.tsx
@@ -14,43 +14,41 @@ export class IntegrationDetailHistoryListView extends React.Component<
 > {
   public render() {
     return (
-      <>
-        <Grid fluid={true} key={1}>
-          {this.props.integrationIsDraft ? (
-            <Grid.Row className="show-grid">
-              <Grid.Col xs={2} md={2}>
-                {<span>{this.props.i18nTextDraft}:</span>}
-              </Grid.Col>
-              <Grid.Col xs={10} md={10}>
-                <ListViewItem
-                  key={1}
-                  heading={this.props.i18nTextDraft}
-                  actions={
-                    <>
-                      <Button>{this.props.i18nTextBtnPublish}</Button>
-                      <Button>{this.props.i18nTextBtnEdit}</Button>
-                    </>
-                  }
-                  stacked={false}
-                />
-              </Grid.Col>
-            </Grid.Row>
-          ) : null}
+      <Grid fluid={true} key={1}>
+        {this.props.integrationIsDraft ? (
+          <Grid.Row className="show-grid">
+            <Grid.Col xs={2} md={2}>
+              {this.props.i18nTextDraft}:
+            </Grid.Col>
+            <Grid.Col xs={10} md={10}>
+              <ListViewItem
+                key={1}
+                heading={this.props.i18nTextDraft}
+                actions={
+                  <>
+                    <Button>{this.props.i18nTextBtnPublish}</Button>
+                    <Button>{this.props.i18nTextBtnEdit}</Button>
+                  </>
+                }
+                stacked={false}
+              />
+            </Grid.Col>
+          </Grid.Row>
+        ) : null}
 
-          {this.props.children ? (
-            <Grid.Row className="show-grid">
-              <Grid.Col xs={2} md={2}>
-                {<span>{this.props.i18nTextHistory}:</span>}
-              </Grid.Col>
-              <Grid.Col xs={10} md={10}>
-                {this.props.children ? (
-                  <ListView>{this.props.children}</ListView>
-                ) : null}
-              </Grid.Col>
-            </Grid.Row>
-          ) : null}
-        </Grid>
-      </>
+        {this.props.children ? (
+          <Grid.Row className="show-grid">
+            <Grid.Col xs={2} md={2}>
+              {<span>{this.props.i18nTextHistory}:</span>}
+            </Grid.Col>
+            <Grid.Col xs={10} md={10}>
+              {this.props.children ? (
+                <ListView>{this.props.children}</ListView>
+              ) : null}
+            </Grid.Col>
+          </Grid.Row>
+        ) : null}
+      </Grid>
     );
   }
 }

--- a/packages/ui/src/Integration/IntegrationDetailHistoryListView.tsx
+++ b/packages/ui/src/Integration/IntegrationDetailHistoryListView.tsx
@@ -1,3 +1,4 @@
+import { Grid } from 'patternfly-react';
 import * as React from 'react';
 
 export interface IIntegrationDetailHistoryListViewProps {
@@ -9,6 +10,28 @@ export class IntegrationDetailHistoryListView extends React.Component<
   IIntegrationDetailHistoryListViewProps
 > {
   public render() {
-    return <></>;
+    return (
+      <>
+        <Grid fluid={true} key={1}>
+          <Grid.Row className="show-grid">
+            <Grid.Col xs={2} md={2}>
+              {<span>{this.props.i18nTextDraft}:</span>}
+            </Grid.Col>
+            <Grid.Col xs={10} md={10}>
+              <p>blah</p>
+            </Grid.Col>
+          </Grid.Row>
+
+          <Grid.Row className="show-grid">
+            <Grid.Col xs={2} md={2}>
+              {<span>{this.props.i18nTextHistory}:</span>}
+            </Grid.Col>
+            <Grid.Col xs={10} md={10}>
+              <p>blah</p>
+            </Grid.Col>
+          </Grid.Row>
+        </Grid>
+      </>
+    );
   }
 }

--- a/packages/ui/src/Integration/IntegrationDetailHistoryListView.tsx
+++ b/packages/ui/src/Integration/IntegrationDetailHistoryListView.tsx
@@ -1,7 +1,10 @@
-import { Grid } from 'patternfly-react';
+import { Button, Grid, ListView, ListViewItem } from 'patternfly-react';
 import * as React from 'react';
 
 export interface IIntegrationDetailHistoryListViewProps {
+  integrationIsDraft: boolean;
+  i18nTextBtnEdit?: string;
+  i18nTextBtnPublish?: string;
   i18nTextDraft?: string;
   i18nTextHistory?: string;
 }
@@ -13,23 +16,39 @@ export class IntegrationDetailHistoryListView extends React.Component<
     return (
       <>
         <Grid fluid={true} key={1}>
-          <Grid.Row className="show-grid">
-            <Grid.Col xs={2} md={2}>
-              {<span>{this.props.i18nTextDraft}:</span>}
-            </Grid.Col>
-            <Grid.Col xs={10} md={10}>
-              <p>blah</p>
-            </Grid.Col>
-          </Grid.Row>
+          {this.props.integrationIsDraft ? (
+            <Grid.Row className="show-grid">
+              <Grid.Col xs={2} md={2}>
+                {<span>{this.props.i18nTextDraft}:</span>}
+              </Grid.Col>
+              <Grid.Col xs={10} md={10}>
+                <ListViewItem
+                  key={1}
+                  heading={this.props.i18nTextDraft}
+                  actions={
+                    <>
+                      <Button>{this.props.i18nTextBtnPublish}</Button>
+                      <Button>{this.props.i18nTextBtnEdit}</Button>
+                    </>
+                  }
+                  stacked={false}
+                />
+              </Grid.Col>
+            </Grid.Row>
+          ) : null}
 
-          <Grid.Row className="show-grid">
-            <Grid.Col xs={2} md={2}>
-              {<span>{this.props.i18nTextHistory}:</span>}
-            </Grid.Col>
-            <Grid.Col xs={10} md={10}>
-              <p>blah</p>
-            </Grid.Col>
-          </Grid.Row>
+          {this.props.children ? (
+            <Grid.Row className="show-grid">
+              <Grid.Col xs={2} md={2}>
+                {<span>{this.props.i18nTextHistory}:</span>}
+              </Grid.Col>
+              <Grid.Col xs={10} md={10}>
+                {this.props.children ? (
+                  <ListView>{this.props.children}</ListView>
+                ) : null}
+              </Grid.Col>
+            </Grid.Row>
+          ) : null}
         </Grid>
       </>
     );

--- a/packages/ui/src/Integration/IntegrationDetailHistoryListView.tsx
+++ b/packages/ui/src/Integration/IntegrationDetailHistoryListView.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+export interface IIntegrationDetailHistoryListViewProps {
+  i18nTextDraft?: string;
+  i18nTextHistory?: string;
+}
+
+export class IntegrationDetailHistoryListView extends React.Component<
+  IIntegrationDetailHistoryListViewProps
+> {
+  public render() {
+    return <></>;
+  }
+}

--- a/packages/ui/src/Integration/IntegrationDetailHistoryListViewItem.tsx
+++ b/packages/ui/src/Integration/IntegrationDetailHistoryListViewItem.tsx
@@ -8,7 +8,7 @@ import {
 import * as React from 'react';
 
 export interface IIntegrationDetailHistoryListViewItemProps {
-  integrationUpdatedAt: Date;
+  integrationUpdatedAt: string;
   integrationVersion: number;
   i18nTextHistoryMenuReplaceDraft?: string;
   i18nTextHistoryMenuUnpublish?: string;

--- a/packages/ui/src/Integration/IntegrationDetailHistoryListViewItem.tsx
+++ b/packages/ui/src/Integration/IntegrationDetailHistoryListViewItem.tsx
@@ -1,5 +1,4 @@
 import {
-  Button,
   DropdownKebab,
   ListView,
   ListViewInfoItem,
@@ -9,17 +8,11 @@ import {
 import * as React from 'react';
 
 export interface IIntegrationDetailHistoryListViewItemProps {
-  integrationIsDraft?: boolean;
-  integrationUpdatedAt?: Date;
-  integrationVersion?: number;
-  i18nTextBtnEdit?: string;
-  i18nTextBtnPublish?: string;
-  i18nTextDraft?: string;
-  i18nTextHistory?: string;
+  integrationUpdatedAt: Date;
+  integrationVersion: number;
   i18nTextHistoryMenuReplaceDraft?: string;
   i18nTextHistoryMenuUnpublish?: string;
   i18nTextLastPublished?: string;
-  i18nTextTitle?: string;
   i18nTextVersion?: string;
 }
 
@@ -32,49 +25,30 @@ export class IntegrationDetailHistoryListViewItem extends React.Component<
         <ListViewItem
           key={1}
           heading={
-            this.props.integrationIsDraft ? (
-              <>{this.props.i18nTextDraft}</>
-            ) : (
-              <span>
-                {<span>{this.props.i18nTextVersion}:</span>}{' '}
-                {this.props.integrationVersion}
-              </span>
-            )
+            <span>
+              {<span>{this.props.i18nTextVersion}:</span>}{' '}
+              {this.props.integrationVersion}
+            </span>
           }
           actions={
-            this.props.integrationIsDraft ? (
-              <>
-                <Button>{this.props.i18nTextBtnPublish}</Button>
-                <Button>{this.props.i18nTextBtnEdit}</Button>
-              </>
-            ) : (
-              <DropdownKebab id="action2kebab" pullRight={true}>
-                <MenuItem>
-                  {this.props.i18nTextHistoryMenuReplaceDraft}
-                </MenuItem>
-                <MenuItem>{this.props.i18nTextHistoryMenuUnpublish}</MenuItem>
-              </DropdownKebab>
-            )
+            <DropdownKebab id="action2kebab" pullRight={true}>
+              <MenuItem>{this.props.i18nTextHistoryMenuReplaceDraft}</MenuItem>
+              <MenuItem>{this.props.i18nTextHistoryMenuUnpublish}</MenuItem>
+            </DropdownKebab>
           }
-          additionalInfo={
-            !this.props.integrationIsDraft
-              ? [
-                  <ListViewInfoItem key={1}>
-                    {this.props.i18nTextLastPublished}
-                    {this.props.integrationUpdatedAt}
-                  </ListViewInfoItem>,
-                ]
-              : null
-          }
+          additionalInfo={[
+            <ListViewInfoItem key={1}>
+              {this.props.i18nTextLastPublished}
+              {this.props.integrationUpdatedAt}
+            </ListViewInfoItem>,
+          ]}
           leftContent={
-            !this.props.integrationIsDraft ? (
-              <ListView.Icon
-                type="pf"
-                name="ok"
-                size="xs"
-                className="list-view-pf-icon-success"
-              />
-            ) : null
+            <ListView.Icon
+              type="pf"
+              name="ok"
+              size="xs"
+              className="list-view-pf-icon-success"
+            />
           }
           stacked={false}
         />

--- a/packages/ui/src/Integration/index.ts
+++ b/packages/ui/src/Integration/index.ts
@@ -1,5 +1,6 @@
 export * from './IntegrationActionConfigurationCard';
 export * from './IntegrationActionSelectorCard';
+export * from './IntegrationDetailHistoryListView';
 export * from './IntegrationDetailHistoryListViewItem';
 export * from './IntegrationEditorLayout';
 export * from './IntegrationFlowAddStep';

--- a/packages/ui/stories/Integration/IntegrationDetailHistoryListView.stories.tsx
+++ b/packages/ui/stories/Integration/IntegrationDetailHistoryListView.stories.tsx
@@ -25,20 +25,20 @@ const i18nTextVersion = 'Version';
 const integrationPublished = {
   id: 'i-LYmlhVFB6pKKaBQVSyez',
   version: 1,
-  updatedAt: 1550261344272,
+  updatedAt: 'Feb 24, 2019, 04:27:49',
   currentState: 'Unpublished',
   targetState: 'Unpublished',
-  name: 'aaa',
+  name: 'Test Published Integration',
   isDraft: false,
 };
 
 const integrationUnpublished = {
   id: 'i-LYmlhVFB6pKKaBQVSyez',
   version: 1,
-  updatedAt: 1550261344272,
+  updatedAt: 'Feb 25, 2019, 11:42:21',
   currentState: 'Unpublished',
   targetState: 'Unpublished',
-  name: 'aaa',
+  name: 'Test Unpublished Integration',
   isDraft: true,
 };
 

--- a/packages/ui/stories/Integration/IntegrationDetailHistoryListView.stories.tsx
+++ b/packages/ui/stories/Integration/IntegrationDetailHistoryListView.stories.tsx
@@ -10,15 +10,51 @@ const stories = storiesOf(
   module
 );
 
+const integrationPublished = {
+  id: 'i-LYmlhVFB6pKKaBQVSyez',
+  version: 1,
+  updatedAt: 1550261344272,
+  currentState: 'Unpublished',
+  targetState: 'Unpublished',
+  name: 'aaa',
+  isDraft: false,
+};
+
+const integrationUnpublished = {
+  id: 'i-LYmlhVFB6pKKaBQVSyez',
+  version: 1,
+  updatedAt: 1550261344272,
+  currentState: 'Unpublished',
+  targetState: 'Unpublished',
+  name: 'aaa',
+  isDraft: true,
+};
+
+const i18nTextBtnEdit = 'Edit';
+const i18nTextBtnPublish = 'Publish';
 const i18nTextDraft = 'Draft';
 const i18nTextHistory = 'History';
 
-stories.add(
-  'has history',
-  withNotes('Verify there is a list of history items')(() => (
-    <IntegrationDetailHistoryListView
-      i18nTextDraft={text('i18nTextDraft', i18nTextDraft)}
-      i18nTextHistory={text('i18nTextHistory', i18nTextHistory)}
-    />
-  ))
-);
+stories
+  .add(
+    'published',
+    withNotes('Verify there is no Publish button')(() => (
+      <IntegrationDetailHistoryListView
+        integrationIsDraft={integrationPublished.isDraft}
+        i18nTextDraft={text('i18nTextDraft', i18nTextDraft)}
+        i18nTextHistory={text('i18nTextHistory', i18nTextHistory)}
+      />
+    ))
+  )
+  .add(
+    'draft, no published history',
+    withNotes('Verify there is a Publish button')(() => (
+      <IntegrationDetailHistoryListView
+        integrationIsDraft={integrationUnpublished.isDraft}
+        i18nTextBtnEdit={text('i18nTextBtnEdit', i18nTextBtnEdit)}
+        i18nTextBtnPublish={text('i18nTextBtnPublish', i18nTextBtnPublish)}
+        i18nTextDraft={text('i18nTextDraft', i18nTextDraft)}
+        i18nTextHistory={text('i18nTextHistory', i18nTextHistory)}
+      />
+    ))
+  );

--- a/packages/ui/stories/Integration/IntegrationDetailHistoryListView.stories.tsx
+++ b/packages/ui/stories/Integration/IntegrationDetailHistoryListView.stories.tsx
@@ -15,7 +15,7 @@ const i18nTextHistory = 'History';
 
 stories.add(
   'has history',
-  withNotes('Verify there is a Publish button')(() => (
+  withNotes('Verify there is a list of history items')(() => (
     <IntegrationDetailHistoryListView
       i18nTextDraft={text('i18nTextDraft', i18nTextDraft)}
       i18nTextHistory={text('i18nTextHistory', i18nTextHistory)}

--- a/packages/ui/stories/Integration/IntegrationDetailHistoryListView.stories.tsx
+++ b/packages/ui/stories/Integration/IntegrationDetailHistoryListView.stories.tsx
@@ -1,0 +1,24 @@
+import { text } from '@storybook/addon-knobs';
+import { withNotes } from '@storybook/addon-notes';
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+
+import { IntegrationDetailHistoryListView } from '../../src';
+
+const stories = storiesOf(
+  'Integration/IntegrationDetailHistoryListView',
+  module
+);
+
+const i18nTextDraft = 'Draft';
+const i18nTextHistory = 'History';
+
+stories.add(
+  'has history',
+  withNotes('Verify there is a Publish button')(() => (
+    <IntegrationDetailHistoryListView
+      i18nTextDraft={text('i18nTextDraft', i18nTextDraft)}
+      i18nTextHistory={text('i18nTextHistory', i18nTextHistory)}
+    />
+  ))
+);

--- a/packages/ui/stories/Integration/IntegrationDetailHistoryListView.stories.tsx
+++ b/packages/ui/stories/Integration/IntegrationDetailHistoryListView.stories.tsx
@@ -3,12 +3,24 @@ import { withNotes } from '@storybook/addon-notes';
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 
-import { IntegrationDetailHistoryListView } from '../../src';
+import {
+  IntegrationDetailHistoryListView,
+  IntegrationDetailHistoryListViewItem,
+} from '../../src';
 
 const stories = storiesOf(
   'Integration/IntegrationDetailHistoryListView',
   module
 );
+
+const i18nTextBtnEdit = 'Edit';
+const i18nTextBtnPublish = 'Publish';
+const i18nTextDraft = 'Draft';
+const i18nTextHistory = 'History';
+const i18nTextHistoryMenuReplaceDraft = 'Replace Draft';
+const i18nTextHistoryMenuUnpublish = 'Unpublish';
+const i18nTextLastPublished = 'Last published on ';
+const i18nTextVersion = 'Version';
 
 const integrationPublished = {
   id: 'i-LYmlhVFB6pKKaBQVSyez',
@@ -30,10 +42,29 @@ const integrationUnpublished = {
   isDraft: true,
 };
 
-const i18nTextBtnEdit = 'Edit';
-const i18nTextBtnPublish = 'Publish';
-const i18nTextDraft = 'Draft';
-const i18nTextHistory = 'History';
+const integrationPublishedHistoryItems = [
+  <IntegrationDetailHistoryListViewItem
+    key={0}
+    integrationUpdatedAt={text(
+      'integrationUpdatedAt',
+      integrationPublished.updatedAt
+    )}
+    integrationVersion={text(
+      'integrationVersion',
+      integrationPublished.version
+    )}
+    i18nTextHistoryMenuReplaceDraft={text(
+      'i18nTextHistoryMenuReplaceDraft',
+      i18nTextHistoryMenuReplaceDraft
+    )}
+    i18nTextHistoryMenuUnpublish={text(
+      'i18nTextHistoryMenuUnpublish',
+      i18nTextHistoryMenuUnpublish
+    )}
+    i18nTextLastPublished={text('i18nTextLastPublished', i18nTextLastPublished)}
+    i18nTextVersion={text('i18nTextVersion', i18nTextVersion)}
+  />,
+];
 
 stories
   .add(
@@ -41,6 +72,7 @@ stories
     withNotes('Verify there is no Publish button')(() => (
       <IntegrationDetailHistoryListView
         integrationIsDraft={integrationPublished.isDraft}
+        children={integrationPublishedHistoryItems}
         i18nTextDraft={text('i18nTextDraft', i18nTextDraft)}
         i18nTextHistory={text('i18nTextHistory', i18nTextHistory)}
       />

--- a/packages/ui/stories/Integration/IntegrationDetailHistoryListViewItem.stories.tsx
+++ b/packages/ui/stories/Integration/IntegrationDetailHistoryListViewItem.stories.tsx
@@ -20,73 +20,39 @@ const integrationPublished = {
   isDraft: false,
 };
 
-const integrationUnpublished = {
-  id: 'i-LYmlhVFB6pKKaBQVSyez',
-  version: 1,
-  updatedAt: 1550261344272,
-  currentState: 'Unpublished',
-  targetState: 'Unpublished',
-  name: 'aaa',
-  isDraft: true,
-};
-
-const i18nTextBtnEdit = 'Edit';
-const i18nTextBtnPublish = 'Publish';
-const i18nTextDraft = 'Draft';
 const i18nTextHistoryMenuReplaceDraft = 'Replace Draft';
 const i18nTextHistoryMenuUnpublish = 'Unpublish';
 const i18nTextLastPublished = 'Last published on ';
 const i18nTextTitle = 'Integration Detail';
 const i18nTextVersion = 'Version';
 
-stories
-  .add(
-    'published',
-    withNotes('Verify there is no Publish button')(() => (
-      <IntegrationDetailHistoryListViewItem
-        integrationIsDraft={integrationPublished.isDraft}
-        integrationUpdatedAt={text(
-          'integrationUpdatedAt',
-          integrationPublished.updatedAt
-        )}
-        integrationVersion={text(
-          'integrationVersion',
-          integrationPublished.version
-        )}
-        i18nTextHistoryMenuReplaceDraft={text(
-          'i18nTextHistoryMenuReplaceDraft',
-          i18nTextHistoryMenuReplaceDraft
-        )}
-        i18nTextHistoryMenuUnpublish={text(
-          'i18nTextHistoryMenuUnpublish',
-          i18nTextHistoryMenuUnpublish
-        )}
-        i18nTextLastPublished={text(
-          'i18nTextLastPublished',
-          i18nTextLastPublished
-        )}
-        i18nTextTitle={text('i18nTextTitle', i18nTextTitle)}
-        i18nTextVersion={text('i18nTextVersion', i18nTextVersion)}
-      />
-    ))
-  )
-  .add(
-    'draft, no published history',
-    withNotes('Verify there is a Publish button')(() => (
-      <IntegrationDetailHistoryListViewItem
-        integrationIsDraft={integrationUnpublished.isDraft}
-        integrationVersion={text(
-          'integrationVersion',
-          integrationUnpublished.version
-        )}
-        i18nTextBtnEdit={text('i18nTextBtnEdit', i18nTextBtnEdit)}
-        i18nTextBtnPublish={text('i18nTextBtnPublish', i18nTextBtnPublish)}
-        i18nTextDraft={text('i18nTextDraft', i18nTextDraft)}
-        i18nTextHistoryMenuReplaceDraft={text(
-          'i18nTextHistoryMenuReplaceDraft',
-          i18nTextHistoryMenuReplaceDraft
-        )}
-        i18nTextTitle={text('i18nTextTitle', i18nTextTitle)}
-      />
-    ))
-  );
+stories.add(
+  'published',
+  withNotes('Verify there is a list of history items')(() => (
+    <IntegrationDetailHistoryListViewItem
+      integrationIsDraft={integrationPublished.isDraft}
+      integrationUpdatedAt={text(
+        'integrationUpdatedAt',
+        integrationPublished.updatedAt
+      )}
+      integrationVersion={text(
+        'integrationVersion',
+        integrationPublished.version
+      )}
+      i18nTextHistoryMenuReplaceDraft={text(
+        'i18nTextHistoryMenuReplaceDraft',
+        i18nTextHistoryMenuReplaceDraft
+      )}
+      i18nTextHistoryMenuUnpublish={text(
+        'i18nTextHistoryMenuUnpublish',
+        i18nTextHistoryMenuUnpublish
+      )}
+      i18nTextLastPublished={text(
+        'i18nTextLastPublished',
+        i18nTextLastPublished
+      )}
+      i18nTextTitle={text('i18nTextTitle', i18nTextTitle)}
+      i18nTextVersion={text('i18nTextVersion', i18nTextVersion)}
+    />
+  ))
+);

--- a/packages/ui/stories/Integration/IntegrationDetailHistoryListViewItem.stories.tsx
+++ b/packages/ui/stories/Integration/IntegrationDetailHistoryListViewItem.stories.tsx
@@ -11,26 +11,19 @@ const stories = storiesOf(
 );
 
 const integrationPublished = {
-  id: 'i-LYmlhVFB6pKKaBQVSyez',
   version: 1,
   updatedAt: 1550261344272,
-  currentState: 'Unpublished',
-  targetState: 'Unpublished',
-  name: 'aaa',
-  isDraft: false,
 };
 
 const i18nTextHistoryMenuReplaceDraft = 'Replace Draft';
 const i18nTextHistoryMenuUnpublish = 'Unpublish';
 const i18nTextLastPublished = 'Last published on ';
-const i18nTextTitle = 'Integration Detail';
 const i18nTextVersion = 'Version';
 
 stories.add(
   'published',
   withNotes('Verify there is a list of history items')(() => (
     <IntegrationDetailHistoryListViewItem
-      integrationIsDraft={integrationPublished.isDraft}
       integrationUpdatedAt={text(
         'integrationUpdatedAt',
         integrationPublished.updatedAt
@@ -51,7 +44,6 @@ stories.add(
         'i18nTextLastPublished',
         i18nTextLastPublished
       )}
-      i18nTextTitle={text('i18nTextTitle', i18nTextTitle)}
       i18nTextVersion={text('i18nTextVersion', i18nTextVersion)}
     />
   ))

--- a/packages/ui/stories/Integration/IntegrationDetailHistoryListViewItem.stories.tsx
+++ b/packages/ui/stories/Integration/IntegrationDetailHistoryListViewItem.stories.tsx
@@ -12,7 +12,7 @@ const stories = storiesOf(
 
 const integrationPublished = {
   version: 1,
-  updatedAt: 1550261344272,
+  updatedAt: 'Feb 24, 2019, 04:27:49',
 };
 
 const i18nTextHistoryMenuReplaceDraft = 'Replace Draft';


### PR DESCRIPTION
Opening this as a WIP/Draft Pull Request as I have some questions before I make this ready for review. Will also try to add the other sections of the Details tab if possible.

Changes:
- Add IntegrationDetailHistoryListView component and story.
- The history section, slightly confusingly, includes a row for Draft options, and then a series of rows for History items, see [this](https://syndesis-staging.b6ff.rh-idev.openshiftapps.com/integrations/i-LYmlhVFB6pKKaBQVSyez) example in staging. So, I have moved the Draft row of options to this here List View component and story (from the List View Item), as it made it easier to work with the data.


Questions:
- ~Is it possible to extract data for stories that would like to reference the same data item? For example, some integration properties (e.g. `version`, `updatedAt`) are used in multiple integration detail-related stories, so at the moment I just copy and paste them into each story.~