### PR TITLE
fix(readme): correct broken links, improve getting started steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Syndesis is a single page application built with React.
   - [Architecture](#architecture)
     - [syndesis](#syndesis)
       - [Development server](#development-server)
-        - [Resetting the configuration](#resetting-the-configuration)
     - [packages](#packages)
       - [packages/api](#packagesapi)
         - [Development server](#development-server-1)
@@ -36,7 +35,7 @@ Syndesis is a single page application built with React.
         - [Nested translation](#nested-translation)
         - [Translation as an argument to another translation](#translation-as-an-argument-to-another-translation)
         - [Adding plurals to a translation](#adding-plurals-to-a-translation)
-  - [Routing](#routing)        
+  - [Routing](#routing)
     - [Introduction to routing](#introduction-to-routing)
     - [App's routes and resolvers](#apps-routes-and-resolvers)
     - [Routes and app state (AKA passing data between routes)](#routes-and-app-state-aka-passing-data-between-routes)
@@ -45,12 +44,12 @@ Syndesis is a single page application built with React.
       - [Where we are going there ~~are no roads~~ is no app state](#where-we-are-going-there-are-no-roads-is-no-app-state)
   - [License](#license)
 
-## Architecture 
+## Architecture
 
-We use [Lerna](https://github.com/lerna/lerna) to streamline the development process; the most common operations, 
-such as building the project or running the development mode can be done directly from the project root.  
+We use [Lerna](https://github.com/lerna/lerna) to streamline the development process; the most common operations,
+such as building the project or running the development mode can be done directly from the project root.
 
-Code is split in many packages, organized as a monorepo using [Yarn's workspaces](https://yarnpkg.com/lang/en/docs/workspaces/). 
+Code is split in many packages, organized as a monorepo using [Yarn's workspaces](https://yarnpkg.com/lang/en/docs/workspaces/).
 The workspace is configured like this:
 
 ```
@@ -62,7 +61,7 @@ The workspace is configured like this:
 ### syndesis
 
 `syndesis` is the main application. It handles the authentication against Syndesis's OAuth Server, and provides the main
- app layout where "sub-apps" can be injected. 
+ app layout where "sub-apps" can be injected.
 
 ![](doc/assets/syndesis-chrome.png)
 
@@ -70,14 +69,21 @@ It's built with [create-react-app](https://github.com/facebook/create-react-app)
 
 #### Development server
 
+_Before you launch the dev server, ensure you've done the following;_
+
+- `minishift start` # ensure minishift is running
+- `eval $(minishift docker-env)` # set the docker environment variable
+- `eval $(minishift oc-env)` # set the openshift environment variable
+- `oc login -u developer` # login under the developer account
+- `oc project syndesis` # ensure you're using the correct project
+
+_Now, you should be ready to_
+
 ```bash
 $ yarn watch:app
 ```
 
-##### Resetting the configuration
-
-Just clear the local storage for the localhost:3000 origin. You can do it with Chrome Dev Tools opened on the running app,
-or you can do it from Chrome's special URL: chrome://settings/siteData  
+_Now run `oc get route syndesis  --template={{.spec.host}}` in your console and use the output from that as the URL for the app's development server._
 
 ###  packages
 
@@ -91,7 +97,6 @@ to ease interacting with Syndesis's Backend.
 ```bash
 $ yarn watch:packages --scope @syndesis/api
 ```
- 
 
 #### packages/models
 
@@ -100,11 +105,11 @@ This package contains the TypeScript definitions of the models, as read from the
 
 #### packages/ui
 
-This package contains a collection of UI elements that are common across the application. 
+This package contains a collection of UI elements that are common across the application.
 
-All the elements are written as React PureComponents or Stateless Functional Components. The idea is to decouple the 
+All the elements are written as React PureComponents or Stateless Functional Components. The idea is to decouple the
 presentation from the model that holds the data that needs to be presented to promote code reuse and easing the testing
-efforts. 
+efforts.
 
 ##### Development server
 
@@ -114,14 +119,14 @@ $ yarn watch:packages --scope @syndesis/ui
 
 ##### Storybook
 
-This package provides a [Storybook](https://storybook.js.org) to develop and document the components in isolation.  
+This package provides a [Storybook](https://storybook.js.org) to develop and document the components in isolation.
 Storybook can be launched like this:
 
 ```bash
 # From the package folder
 $ yarn storybook
 ```
-  
+
 A browser tab should eventually be opened pointing on [http://localhost:90001](http://localhost:90001).
 
 #### packages/utils
@@ -138,11 +143,11 @@ $ yarn watch:packages --scope @syndesis/utils
 
 Extra typings for pure JavaScript dependencies that should eventually be pushed on [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/).
 
-## Installation 
+## Installation
 
 [Yarn](https://yarnpkg.com) is the package manager required to work on the project.
 
-To install all the dependencies: 
+To install all the dependencies:
 
 ##### Development server
 
@@ -160,25 +165,14 @@ yarn build
 
 ## Scripts
 
-To start the development server for `syndesis` and watch for changes in any of the packages:
-
-```bash
-$ yarn watch
-```
-_**IMPORTANT:** you must have successfully built all the packages _before_ running the watch command to successfully 
-run this command._    
-_**ALSO IMPORTANT:** this will change the `syndesis-ui` POD to point to your development server. To 
-restore the POD to the original state, you will have to manually run `yarn minishift:restore`_
-
 To start the development server only for `syndesis`:
 
 ```bash
 $ yarn watch:app
 ```
-_The development server for the app will not be available at [http://localhost:3000](http://localhost:3000)_  
-_**IMPORTANT:** you must have successfully built all the packages _before_ running the watch command to successfully 
-run this command._    
-_**ALSO IMPORTANT:** this will change the `syndesis-ui` POD to point to your development server. To 
+
+_**IMPORTANT:** you must have successfully built all the packages _before_ running the watch command._<br>
+_**ALSO IMPORTANT:** this will change the `syndesis-ui` POD to point to your development server. To
 restore the POD to the original state, you will have to manually run `yarn minishift:restore`_
 
 To start the development server only for the packages:
@@ -192,6 +186,17 @@ To start the development server for a specific package you can pass the package 
 ```bash
 $ yarn watch:packages --scope @syndesis/package-name
 ```
+
+To start the development server for `syndesis` and watch for changes in any of the packages:
+
+```bash
+$ yarn watch
+```
+_**IMPORTANT:** you must have successfully built all the packages _before_ running the watch command to successfully
+run this command._<br>
+_**ALSO IMPORTANT:** just like `yarn watch:app`, this will change the `syndesis-ui` POD to point to your development server. To
+restore the POD to the original state, you will have to manually run `yarn minishift:restore`_<br>
+_**ALSO IMPORTANT:** yarn watch is known to cause `JavaScript heap out of memory` errors, probably better to watch the specific pkg(s) you're working on_
 
 To run the test suite:
 
@@ -218,7 +223,7 @@ The [syndesis package](#architecture) is the **only** package where we are using
 
 If [packages](#architecture) other than the `syndesis` package require translation, the already translated text should be passed into those packages using the custom properties of the component. **Do not modify the packages' `package.json` to add dependencies to the *i18n* framework!** We are doing it this way to facilitate testing and to remove the impact of changing the *i18n* library, should we ever need to do that. Here is an example of how you would do that:
 
-```react
+```typescript
 export interface ILinkProps {
   linkRoute: string;
   i18LinkText: string;
@@ -238,8 +243,8 @@ export class MyLink extends React.Component<ILinkProps> {
 }
 ```
 
-In order to get internalization working in our app, a specific [i18next instance](https://react.i18next.com/components/i18next-instance) needs to be configured. We do this in the `syndesis/src/i18n` folder. Here is how that folder is organized:
-- `index.ts` - configures our *i18next instance*. You can find more information about `i18next` settings at [i18next.com](https://www.i18next.com/overview/configuration-options) and the `react-i18n` additional settings at [react.i18next.com](https://react.i18next.com/components/i18next-instance).
+In order to get internalization working in our app, a specific [i18next instance](https://react.i18next.com/latest/i18next-instance) needs to be configured. We do this in the `syndesis/src/i18n` folder. Here is how that folder is organized:
+- `index.ts` - configures our *i18next instance*. You can find more information about `i18next` settings at [i18next.com](https://www.i18next.com/overview/configuration-options) and the `react-i18n` additional settings at [react.i18next.com](https://react.i18next.com/latest/i18next-instance).
 - `locales/` - a folder that sets up the *i18n* namespaces and contains the translations shared within the `syndesis/src` codebase.
 - `locales/index.ts` - contains references to all the app translation files.
 - `locales/shared-translations.en.json` - contains the shared English translations and placeholders for the namespaces provided from within `syndesis/src`.
@@ -249,9 +254,9 @@ Now that we have our *i18n instance* configured, we can start *i18n*-ing our cod
 
 **Important**: Adding new namespaces does require changes to be made to the *i18n instance* described above.
 
-**Note**: All namespaces are actually always available by qualfiying the translation key with the namespace. 
+**Note**: All namespaces are actually always available by qualfiying the translation key with the namespace.
 
-When a method returns a *React* element or fragment (like `render()` does), and translations are needed, the [NamespacesConsumer](https://react.i18next.com/components/namespacesconsumer) class is used. Using the `NamespacesConsumer` class in the method gives that method access to the *i18n* framework. It does this by exposing the `t`, or translation function. An array of namespaces, which are setup by your *i18n instance*, is used by the `NamespacesConsumer` to perform the translations. The first namespace in the array **does not** require its keys to be qualified. However, any subsequent namespaces **do** require their keys to be qualified. An example of internationalizing a method like this can be found [here](#internationalizing-a-render-method).
+When a method returns a *React* element or fragment (like `render()` does), and translations are needed, the [NamespacesConsumer](https://react.i18next.com/legacy-v9/namespacesconsumer) class is used. Using the `NamespacesConsumer` class in the method gives that method access to the *i18n* framework. It does this by exposing the `t`, or translation function. An array of namespaces, which are setup by your *i18n instance*, is used by the `NamespacesConsumer` to perform the translations. The first namespace in the array **does not** require its keys to be qualified. However, any subsequent namespaces **do** require their keys to be qualified. An example of internationalizing a method like this can be found [here](#internationalizing-a-render-method).
 
 When translations are needed but you are not in a method that returns a *React* element, or you are in code that is not a method at all, the `NamespacesConsumer` cannot be used. Instead, the *i18n instance* itself is used. For instance, you can translate some text in a `const` that is constructing an instance of an `interface`. See [this](#internationalizing-text-in-a-constant) example.
 
@@ -261,12 +266,12 @@ The following sections give you examples on how to *i18n* things.
 
 To internationalize a `render()` method, do the following:
 
-1. Add this import statement 
-```react
+1. Add this import statement
+```typescript
 import { NamespacesConsumer } from 'react-i18next';
 ```
 1. Wrap what normally would be returned with a `NamespacesConsumer` tag. You need to set the array of namespaces you will be using. The first namespace is the default and does not need to be used when referencing a translation key. Translation keys not found in the default namespace need to be qualified. See [this](#translations-using-different-namespaces) for examples of using namespaces in translations.
-```react
+```typescript
 public render() {
   return (
     <NamespacesConsumer ns={['your-default-namespace', 'additional-namespaces']}>
@@ -285,12 +290,12 @@ public render() {
 To internationalize text in a `const`, do the following:
 
 1. Add this import statement:
-```react
-import i18n from 'relative-path-to-syndesis/src/i18n'; 
+```typescript
+import i18n from 'relative-path-to-syndesis/src/i18n';
 ```
 2. Add translations into your translation files.
 3. Use the `i18n.t` function to perform the translations. [Here](#translation-examples) you will find examples of how to use the `t` function.
-```react
+```typescript
 const sortByName = {
   id: 'name',
   isNumeric: false,
@@ -310,14 +315,14 @@ Some examples taken from the [i18next.com](https://www.i18next.com/translation-f
 }
 ```
 - usage
-```react
+```typescript
 { t('erroMsg') }
 ```
 - outputs: "An error occurred."
 
 ##### Translations using different namespaces
 - usage
-```react
+```typescript
 { t('Connections') } -> uses default namespace translation files
 { t('shared:Name') } -> uses 'shared' namespace translation files
 { t('integrations:topIntegrations') } -> uses 'integrations' namespace translation files
@@ -332,7 +337,7 @@ Some examples taken from the [i18next.com](https://www.i18next.com/translation-f
 }
 ```
 - usage
-```react
+```typescript
 { t('lastNumberOfDays', { numberOfDays: 30 }) }
 { t('favorite', { this: 'Apple', thing: 'fruit' }) }
 ```
@@ -348,7 +353,7 @@ Some examples taken from the [i18next.com](https://www.i18next.com/translation-f
 }
 ```
 - usage
-```react
+```typescript
 { t('nesting1') }
 ```
 - outputs: "1 2 3"
@@ -359,9 +364,10 @@ Some examples taken from the [i18next.com](https://www.i18next.com/translation-f
 {
       "key1": "hello world",
       "key2": "say: {{val}}"
-}```
+}
+```
 - usage
-```react
+```typescript
 { t('key2', { val: '$t(key1)' }) }
 ```
 - outputs: "say: hello world"
@@ -395,9 +401,9 @@ To link to a specific route the `Link` component should be used.
 <Link to={'/foo/bar'}>Take me to FooBar</Link>
 ```
 
-Why a `Link` and not a simple `a`? The `Link` component uses the `history` API to manipulate the navigation history, and the underlying `Router` component listens to changes to the history to trigger the right re-render of the app. This way the app is able to move between pages without the classic "reload" effect of normal websites (AKA [Single Page Application](https://en.wikipedia.org/wiki/Single-page_application)). 
+Why a `Link` and not a simple `a`? The `Link` component uses the `history` API to manipulate the navigation history, and the underlying `Router` component listens to changes to the history to trigger the right re-render of the app. This way the app is able to move between pages without the classic "reload" effect of normal websites (AKA [Single Page Application](https://en.wikipedia.org/wiki/Single-page_application)).
 
-Since a URL is used in many places across the app, it's suggested to use the `named-urls` library to give it a unique name, avoid repetitions, and remove the risk of typos.  
+Since a URL is used in many places across the app, it's suggested to use the `named-urls` library to give it a unique name, avoid repetitions, and remove the risk of typos.
 Unfortunately, this is not a feature that `react-router` provides out of the box, so we use [named-urls](https://github.com/tricoder42/named-urls) to achieve that.  With this library, the previous examples would, instead, look like this:
 
 ```ts
@@ -423,7 +429,7 @@ import routes from './routes';
 <Link to={routes.foo.bar}>Take me to FooBar</Link>
 ```
 
-A route can also accept dynamic parameters. Dynamic parameters are written in the URL string, and their presence can be set as either mandatory or optional. 
+A route can also accept dynamic parameters. Dynamic parameters are written in the URL string, and their presence can be set as either mandatory or optional.
 
 ```tsx
 <Route match={'/bar/:mandatoryParameter/:optionalParameter?'} component={FooBarPage} />
@@ -431,7 +437,7 @@ A route can also accept dynamic parameters. Dynamic parameters are written in th
 <Link to={`/foo/bar/${someVar}/${someOtherVar}`}>Take me to FooBar</Link>
 ```
 
-In this example the `foo.bar` route requires a parameter called `mandatoryParameter` and can take an optional parameter called `optionalParameter`. 
+In this example the `foo.bar` route requires a parameter called `mandatoryParameter` and can take an optional parameter called `optionalParameter`.
 The `Link` component doesn't offer any specific helper to generate the right URL for you, so the right string needs to be programmatically generated depending on your needs.
 
 This approach is extremely error-prone and repetitive. It's better to have some helper function that, provided the right parameters, resolves the URL for you. In the codebase these helpers are called `reducers`.
@@ -455,10 +461,10 @@ import routes from './routes';
 export default {
  foo: {
    bar: (params: { mandatoryParameter: string, optionalParameter: number }) =>
-     reverse(routes.foo.bar, params) 
+     reverse(routes.foo.bar, params)
  }
 };
-```   
+```
 
 ```tsx
 import resolvers from './resolvers';
@@ -475,7 +481,7 @@ This approach brings a number of benefits:
 Downsides are:
 
 - it's very verbose
-- if the URL changes and the resolver isn't updated accordingly, the resolver will not work. *As such, unit testing resolvers is very important.* 
+- if the URL changes and the resolver isn't updated accordingly, the resolver will not work. *As such, unit testing resolvers is very important.*
 
 ### App's routes and resolvers
 
@@ -485,15 +491,15 @@ Each module will take care of its own routes and pages, plus anything else that'
 
 * its _named_ routes definitions in a `routes.ts` file
 * its resolvers in a `resolvers.ts` file
-  
-These two files will then be re-exported by the main app [routes](syndesis/src/modules/routes.ts) and [resolvers](syndesis/src/modules/resolvers.ts) files, to somewhat reduce the coupling between modules. 
+
+These two files will then be re-exported by the main app [routes](syndesis/src/modules/routes.ts) and [resolvers](syndesis/src/modules/resolvers.ts) files, to somewhat reduce the coupling between modules.
 
 ### Routes and app state (i.e. passing data between routes)
 
-Hard rule: a page must be able to render *regardless of the navigation history* that lead the user to it.\*  
+Hard rule: a page must be able to render *regardless of the navigation history* that lead the user to it.\*
 _\* exceptions can be made for pages that act like an actual application, such as a wizard._
 
-#### A simple example  
+#### A simple example
 
 Consider this scenario:
 
@@ -502,25 +508,25 @@ Consider this scenario:
   * `/integrations/detail`, that will render the `IntegrationDetailsPage` component
 * a user is checking the integrations list page (`/integrations`)
 * the user then clicks on the "Details" link next to the integration named `Foo`, changing the url to `/integrations/detail`
-* the `IntegrationDetailsPage` component is then rendered, but... 
-    
+* the `IntegrationDetailsPage` component is then rendered, but...
+
 ...how can the `IntegrationDetailsPage` know that the `Foo` object should be rendered? It has not been "passed" to it yet!
 
 One option would be to make the app stateful storing the object that the user clicked, allowing the details page to retrieve it and properly render. This can be achieved using [React's Context](https://reactjs.org/docs/context.html), or a state management solution like [redux](https://redux.js.org/).
 
 #### URLs as a single source of truth
 
-Let's assume that we have the object in the app state and the `IntegrationDetailsPage` is properly rendering. Everything is good and the problem appears to be solved, but what if the user decides to share the URL - which is `/integrations/detail` - with a colleague? 
+Let's assume that we have the object in the app state and the `IntegrationDetailsPage` is properly rendering. Everything is good and the problem appears to be solved, but what if the user decides to share the URL - which is `/integrations/detail` - with a colleague?
 
 * the user shares the `Foo` details page url with a colleague
 * the colleague clicks the link, and its browser promptly opens it
 * the `IntegrationDetailsPage` assumes that the object to render is available in the app's state, but the object is actually `undefined` and the app crashes with an error
- 
+
 Since our app relies on the user "correctly" following the app's flow to set its state, it doesn't work when the flow is broken. A band-aid could be put in the code to check for the object validity before accessing it, showing some meaningful error message to the user and avoiding a crash, but this wouldn't be the greatest user experience ever.
 
-A better solution would be instead to tell the `IntegrationDetailsPage` enough information about the object that should be rendered, to allow the page to work independently from the rest of the app. 
+A better solution would be instead to tell the `IntegrationDetailsPage` enough information about the object that should be rendered, to allow the page to work independently from the rest of the app.
 
-In this case, it would be as simple as passing the object ID in the URL - which would look something like `/integrations/123-some-id/detail` - and update the page to read the ID from the URL, to then fetch the required data from an API. 
+In this case, it would be as simple as passing the object ID in the URL - which would look something like `/integrations/123-some-id/detail` - and update the page to read the ID from the URL, to then fetch the required data from an API.
 The colleague's experience would now be something like this:
 
 * the user shares the `Foo` details page URL (`/integrations/123-some-id/detail`) with a colleague
@@ -529,24 +535,24 @@ The colleague's experience would now be something like this:
 * in the meantime, some loading indicator is shown to the user to inform that the app is working
 * eventually, the object will be returned to the page, allowing it to properly render
 
-This is a big improvement, because the integration details page is now resilient to the history and app state's state.  
+This is a big improvement, because the integration details page is now resilient to the history and app state's state.
 
 #### Where we are going there ~~are no roads~~ is no app state
- 
-What is the source of truth, the URL or the app state?  
 
-We know that without the ID in the URL our app wouldn't work in some scenarios. But would it work without the app state?  
+What is the source of truth, the URL or the app state?
+
+We know that without the ID in the URL our app wouldn't work in some scenarios. But would it work without the app state?
 
 The answer is yes, it would! When the user clicks on the "Details" link the `IntegrationDetailsPage` simply calls the right API to retrieve the data and render it.
 
 There is only one downside with this approach, which is that the user will see a loading indicator every time the details page is visited. We didn't have this problem with the app state-based solution! Can we achieve the same result without it?
 
-Again, the answer is yes! Under the hood, `react-router` uses the [`history API`](https://developer.mozilla.org/en-US/docs/Web/API/History_API) to modify the history and react to its changes. Whenever a `Link` is clicked, `react-router` will invoke the [`history.pushState` method](https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_pushState()_method) passing the new URL.  
+Again, the answer is yes! Under the hood, `react-router` uses the [`history API`](https://developer.mozilla.org/en-US/docs/Web/API/History_API) to modify the history and react to its changes. Whenever a `Link` is clicked, `react-router` will invoke the [`history.pushState` method](https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_pushState()_method) passing the new URL.
 Reading the documentation, we see that the `pushState` method can take a _state object_ as a parameter:
 
 > The state object is a JavaScript object which is associated with the new history entry created by `pushState()`. Whenever the user navigates to the new state, a popstate event is fired, and the state property of the event contains a copy of the history entry's state object.
 
-What's handy about this is that the serialized object will be saved by the browser and made available to the code whenever that history entry is accessed (eg. after a refresh, a browser crash). 
+What's handy about this is that the serialized object will be saved by the browser and made available to the code whenever that history entry is accessed (eg. after a refresh, a browser crash).
 
 Remember that when displaying the integrations list we already have access to the integration object. We can simply pass the the state object that goes with the URL to the `Link` object, like so:
 
@@ -570,12 +576,12 @@ import routes from './routes';
 export default {
   integrations: {
     list: () => reverse(routes.integrations.list),
-    /* 
-      the `Link`'s `to` parameter takes either a string or an object [1] 
+    /*
+      the `Link`'s `to` parameter takes either a string or an object [1]
       wich can hold a state object.
-      The `details` resolver will ask for an Integration and derive the 
+      The `details` resolver will ask for an Integration and derive the
       right params and state from that.
-      [1] https://reacttraining.com/react-router/web/api/Link/to-object 
+      [1] https://reacttraining.com/react-router/web/api/Link/to-object
     */
     details: (params: { integration: Integration }) => ({
       pathname: reverse(routes.integrations.details, {
@@ -587,7 +593,7 @@ export default {
     })
   }
 };
-```   
+```
 
 ```tsx
 import resolvers from './resolvers';
@@ -611,15 +617,15 @@ interface IIntegrationDetailPageState {
 
 export class IntegrationDetailPage extends React.Component {
   public render() {
-    return (     
+    return (
       {/* this helper will check the history object for us and return the params and state object, as by the provided interfaces */}
       <WithRouteData<IIntegrationDetailPageParams, IIntegrationDetailPageState>>
         {({ integrationId }, { integration }) =>
-           {/* 
-             let's ask the backend to retrieve and integration with ID `integrationId`, 
-             and use `integration` as the initialValue. 
-             If `integration` is a valid object, this action will be synchronous and the 
-             returned `hasData` will be true, allowing us to skip any loading.  
+           {/*
+             let's ask the backend to retrieve and integration with ID `integrationId`,
+             and use `integration` as the initialValue.
+             If `integration` is a valid object, this action will be synchronous and the
+             returned `hasData` will be true, allowing us to skip any loading.
            */}
            <WithIntegration id={integrationId} initialValue={integration}>
              {({ data, hasData, error }) => (
@@ -630,7 +636,7 @@ export class IntegrationDetailPage extends React.Component {
                errorChildren={<div>Ops! Something broke.</div>}
              >
                {() => (
-                 {/* 
+                 {/*
                    `data` will contain our integration object, either loaded asynchronously
                    from the API or returned immediately because the initialData we
                    provided was valid
@@ -644,7 +650,7 @@ export class IntegrationDetailPage extends React.Component {
     );
   }
 }
-```  
+```
 
 We now have a page that is resilient to page refreshes, can be shared with others, and uses the URL as a single source of truth. Plus, with a little help from the browser, we can use history state to improve the user experience.
 

--- a/packages/auto-form/yalc.lock
+++ b/packages/auto-form/yalc.lock
@@ -1,0 +1,4 @@
+{
+  "version": "v1",
+  "packages": {}
+}


### PR DESCRIPTION
This PR cleans up the README. Updating old links, adding some additional info around the getting started steps, and improving the syntax highlighting for code examples.

Sorry about the extra noise for trimming trailing whitespace.