### PR TITLE
Add Customizations Extensions Page stories

### DIFF
--- a/packages/ui/stories/Customization/ExtensionDetail.stories.tsx
+++ b/packages/ui/stories/Customization/ExtensionDetail.stories.tsx
@@ -11,7 +11,10 @@ import {
 
 export const extensionDetailStory = 'step extension in use';
 
-const stories = storiesOf('Customization/ExtensionDetail', module);
+const stories = storiesOf(
+  'Customization/Extensions/Component/ExtensionDetail',
+  module
+);
 
 const integrations = [
   {

--- a/packages/ui/stories/Customization/ExtensionImport.stories.tsx
+++ b/packages/ui/stories/Customization/ExtensionImport.stories.tsx
@@ -5,7 +5,10 @@ import { ExtensionImport } from '../../src';
 
 export const extensionImportStory = 'story-tbd';
 
-const stories = storiesOf('Customization/ExtensionImport', module);
+const stories = storiesOf(
+  'Customization/Extensions/Component/ExtensionImport',
+  module
+);
 const storyNotes = '- Verify something here';
 
 stories.add(

--- a/packages/ui/stories/Customization/ExtensionListItem.stories.tsx
+++ b/packages/ui/stories/Customization/ExtensionListItem.stories.tsx
@@ -5,7 +5,10 @@ import { withNotes } from '@storybook/addon-notes';
 import { storiesOf } from '@storybook/react';
 import { ExtensionListItem } from '../../src';
 
-const stories = storiesOf('Customization/ExtensionListItem', module);
+const stories = storiesOf(
+  'Customization/Extensions/Component/ExtensionListItem',
+  module
+);
 
 const extensionDescription = 'Add a loop';
 const extensionIcon =

--- a/packages/ui/stories/Customization/ExtensionListView.stories.tsx
+++ b/packages/ui/stories/Customization/ExtensionListView.stories.tsx
@@ -72,7 +72,10 @@ const extensions = [
   />,
 ];
 
-const stories = storiesOf('Customization/ExtensionListView', module);
+const stories = storiesOf(
+  'Customization/Extensions/Component/ExtensionListView',
+  module
+);
 
 const hasExtensionsTestNotes =
   '- Verify page title is "' +

--- a/packages/ui/stories/Customization/ExtensionsPage.stories.tsx
+++ b/packages/ui/stories/Customization/ExtensionsPage.stories.tsx
@@ -1,0 +1,141 @@
+import { action } from '@storybook/addon-actions';
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { BrowserRouter as Router } from 'react-router-dom';
+import {
+  Container,
+  ExtensionListItem,
+  ExtensionListView,
+  TabBar,
+  TabBarItem,
+} from '../../src';
+
+storiesOf('Customization/Extensions/ExtensionsPage', module)
+  .add('default scenario: with some extension to show', () => (
+    <Router>
+      <>
+        <Container
+          style={{
+            background: '#fff',
+          }}
+        >
+          <TabBar>
+            <TabBarItem
+              label={'apiConnectorsPageTitle'}
+              to={'#api-connector'}
+            />
+            <TabBarItem label={'extensionsPageTitle'} to={'#extension'} />
+          </TabBar>
+        </Container>
+        <ExtensionListView
+          filterTypes={[]}
+          sortTypes={[]}
+          linkImportExtension={'#link-import'}
+          activeFilters={[]}
+          currentFilterType={{
+            filterType: 'text',
+            id: 'id',
+            placeholder: '',
+            title: '',
+          }}
+          currentSortType={'whatever'}
+          currentValue={''}
+          isSortAscending={true}
+          resultsCount={1}
+          onUpdateCurrentValue={action('onUpdateCurrentValue')}
+          onValueKeyPress={action('onValueKeyPress')}
+          onFilterAdded={action('onFilterAdded')}
+          onSelectFilterType={action('onSelectFilterType')}
+          onFilterValueSelected={action('onFilterValueSelected')}
+          onRemoveFilter={action('onRemoveFilter')}
+          onClearFilters={action('onClearFilters')}
+          onToggleCurrentSortDirection={action('onToggleCurrentSortDirection')}
+          onUpdateCurrentSortType={action('onUpdateCurrentSortType')}
+          i18nDescription={'extensionsPageDescription'}
+          i18nEmptyStateInfo={'emptyStateInfoMessage'}
+          i18nEmptyStateTitle={'emptyStateTitle'}
+          i18nLinkImportExtension={'ImportExtension'}
+          i18nLinkImportExtensionTip={'importExtensionTip'}
+          i18nName={'Name'}
+          i18nNameFilterPlaceholder={'nameFilterPlaceholder'}
+          i18nResultsCount={'resultsCount'}
+          i18nTitle={'extensionsPageTitle'}
+        >
+          <ExtensionListItem
+            detailsPageLink={'#ext-1-details'}
+            extensionDescription={'lorem'}
+            extensionIcon={undefined}
+            extensionId={'abc-123'}
+            extensionName={'Some extension name'}
+            i18nCancelText={'Cancel'}
+            i18nDelete={'Delete'}
+            i18nDeleteModalMessage={'deleteModalMessage'}
+            i18nDeleteModalTitle={'deleteModalTitle'}
+            i18nDeleteTip={'deleteExtensionTip'}
+            i18nDetails={'Details'}
+            i18nDetailsTip={'detailsExtensionTip'}
+            i18nExtensionType={'usedByOne'}
+            i18nUpdate={'Update'}
+            i18nUpdateTip={'updateExtensionTip'}
+            i18nUsedByMessage={'StepExtension'}
+            onDelete={action('onDelete')}
+            onUpdate={action('onUpdate')}
+            usedBy={0}
+          />
+        </ExtensionListView>
+      </>
+    </Router>
+  ))
+  .add('empty scenario: no extensions to show', () => (
+    <Router>
+      <>
+        <Container
+          style={{
+            background: '#fff',
+          }}
+        >
+          <TabBar>
+            <TabBarItem
+              label={'apiConnectorsPageTitle'}
+              to={'#api-connector'}
+            />
+            <TabBarItem label={'extensionsPageTitle'} to={'#extension'} />
+          </TabBar>
+        </Container>
+        <ExtensionListView
+          filterTypes={[]}
+          sortTypes={[]}
+          linkImportExtension={'#link-import'}
+          activeFilters={[]}
+          currentFilterType={{
+            filterType: 'text',
+            id: 'id',
+            placeholder: '',
+            title: '',
+          }}
+          currentSortType={'whatever'}
+          currentValue={''}
+          isSortAscending={true}
+          resultsCount={1}
+          onUpdateCurrentValue={action('onUpdateCurrentValue')}
+          onValueKeyPress={action('onValueKeyPress')}
+          onFilterAdded={action('onFilterAdded')}
+          onSelectFilterType={action('onSelectFilterType')}
+          onFilterValueSelected={action('onFilterValueSelected')}
+          onRemoveFilter={action('onRemoveFilter')}
+          onClearFilters={action('onClearFilters')}
+          onToggleCurrentSortDirection={action('onToggleCurrentSortDirection')}
+          onUpdateCurrentSortType={action('onUpdateCurrentSortType')}
+          i18nDescription={'extensionsPageDescription'}
+          i18nEmptyStateInfo={'emptyStateInfoMessage'}
+          i18nEmptyStateTitle={'emptyStateTitle'}
+          i18nLinkImportExtension={'ImportExtension'}
+          i18nLinkImportExtensionTip={'importExtensionTip'}
+          i18nName={'Name'}
+          i18nNameFilterPlaceholder={'nameFilterPlaceholder'}
+          i18nResultsCount={'resultsCount'}
+          i18nTitle={'extensionsPageTitle'}
+        />
+      </>
+    </Router>
+  ));

--- a/syndesis/src/modules/customizations/pages/ExtensionsPage.tsx
+++ b/syndesis/src/modules/customizations/pages/ExtensionsPage.tsx
@@ -128,7 +128,6 @@ export default class ExtensionsPage extends React.Component {
                             <ExtensionListView
                               filterTypes={filterTypes}
                               sortTypes={sortTypes}
-                              {...this.state}
                               linkImportExtension={resolvers.extensions.import()}
                               resultsCount={filteredAndSorted.length}
                               {...helpers}


### PR DESCRIPTION
This PR thanks to @riccardo-forina and live code share earlier today.

Changes:
- Write stories for Extension Page.
- Group Extension Page stories together in Storybook.
- Remove `this.state` reference no longer in use.

Some screenshots:

<img width="1680" alt="Screenshot 2019-03-20 15 00 30" src="https://user-images.githubusercontent.com/3844502/54712034-af62c300-4b21-11e9-9486-368fa5db013c.png">
<img width="1680" alt="Screenshot 2019-03-20 15 00 44" src="https://user-images.githubusercontent.com/3844502/54712041-b25db380-4b21-11e9-98ac-baeafd68db47.png">
<img width="891" alt="Screenshot 2019-03-20 15 00 59" src="https://user-images.githubusercontent.com/3844502/54712095-d620f980-4b21-11e9-96ae-6f329cb26a35.png">
<img width="896" alt="Screenshot 2019-03-20 15 01 16" src="https://user-images.githubusercontent.com/3844502/54712051-b7bafe00-4b21-11e9-9e6e-26a801900d0f.png">


