### PR TITLE
Fix for Virtualization list EmptyState

### DIFF
--- a/packages/ui/src/Data/Views/ViewList.tsx
+++ b/packages/ui/src/Data/Views/ViewList.tsx
@@ -10,6 +10,7 @@ import { ButtonLink } from '../../Layout';
 import { IListViewToolbarProps, ListViewToolbar } from '../../Shared';
 
 export interface IViewsListViewProps extends IListViewToolbarProps {
+  hasListData: boolean;
   i18nEmptyStateInfo: string;
   i18nEmptyStateTitle: string;
   i18nImportView: string;
@@ -50,7 +51,7 @@ export class ViewListView extends React.Component<IViewsListViewProps> {
             </OverlayTrigger>
           </div>
         </ListViewToolbar>
-        {this.props.children ? (
+        {this.props.hasListData ? (
           <ListView>{this.props.children}</ListView>
         ) : (
           <EmptyState>

--- a/packages/ui/src/Data/Virtualizations/VirtualizationList.tsx
+++ b/packages/ui/src/Data/Virtualizations/VirtualizationList.tsx
@@ -11,6 +11,7 @@ import { ButtonLink, Container } from '../../Layout';
 import { IListViewToolbarProps, ListViewToolbar } from '../../Shared';
 
 export interface IVirtualizationListProps extends IListViewToolbarProps {
+  hasListData: boolean;
   i18nCreateDataVirtualization: string;
   i18nCreateDataVirtualizationTip?: string;
   i18nDescription: string;
@@ -90,7 +91,7 @@ export class VirtualizationList extends React.Component<
             </OverlayTrigger>
           </div>
         </ListViewToolbar>
-        {this.props.children ? (
+        {this.props.hasListData ? (
           <ListView>{this.props.children}</ListView>
         ) : (
           <EmptyState>

--- a/packages/ui/stories/Data/Views/ViewList.stories.tsx
+++ b/packages/ui/stories/Data/Views/ViewList.stories.tsx
@@ -166,6 +166,7 @@ stories
           i18nResultsCount={text('i18nResultsCount', '0 Results')}
           onImportView={action(importActionText)}
           children={[]}
+          hasListData={false}
         />
       </Router>
     ))
@@ -218,6 +219,7 @@ stories
           )}
           onImportView={action(importActionText)}
           children={viewItems}
+          hasListData={true}
         />
       </Router>
     ))

--- a/packages/ui/stories/Data/Virtualizations/VirtualizationList.stories.tsx
+++ b/packages/ui/stories/Data/Virtualizations/VirtualizationList.stories.tsx
@@ -281,6 +281,7 @@ stories
           i18nTitle={text('i18nTitle', title)}
           onImport={action(importText)}
           children={[]}
+          hasListData={false}
         />
       </Router>
     ))
@@ -343,6 +344,7 @@ stories
           i18nTitle={text('i18nTitle', title)}
           onImport={action(importText)}
           children={virtualizationItems}
+          hasListData={true}
         />
       </Router>
     ))
@@ -405,6 +407,7 @@ stories
           i18nTitle={text('i18nTitle', title)}
           onImport={action(importText)}
           children={virtItem}
+          hasListData={true}
         />
       </Router>
     ))

--- a/syndesis/src/modules/data/pages/VirtualizationsPage.tsx
+++ b/syndesis/src/modules/data/pages/VirtualizationsPage.tsx
@@ -167,6 +167,7 @@ export default class VirtualizationsPage extends React.Component {
                             )}
                             linkCreateHRef={resolvers.virtualizations.create()}
                             onImport={this.handleImportVirt}
+                            hasListData={data.length > 0}
                           >
                             <WithLoader
                               error={error}


### PR DESCRIPTION
Fixes issue where EmptyState was not being displayed for the virtualization and view list.  The page is now responsible for setting when the list has data.