### PR TITLE
feat: adds some error resilience to the UI

### DIFF
--- a/packages/ui/src/Integration/IntegrationsListItemUnreadable.tsx
+++ b/packages/ui/src/Integration/IntegrationsListItemUnreadable.tsx
@@ -1,0 +1,23 @@
+import { ListView } from 'patternfly-react';
+import * as React from 'react';
+import { ButtonLink } from '../Layout';
+
+export interface IIntegrationsListItemUnreadableProps {
+  integrationName: string;
+  i18nDescription: string;
+  rawObject: string;
+}
+
+export const IntegrationsListItemUnreadable: React.FC<
+  IIntegrationsListItemUnreadableProps
+> = ({ integrationName, i18nDescription, rawObject }) => {
+  const onClick = () => window.alert(rawObject);
+  return (
+    <ListView.Item
+      heading={integrationName}
+      actions={<ButtonLink onClick={onClick}>Integration JSON</ButtonLink>}
+      description={i18nDescription}
+      stacked={true}
+    />
+  );
+};

--- a/packages/ui/src/Integration/index.ts
+++ b/packages/ui/src/Integration/index.ts
@@ -27,5 +27,6 @@ export * from './IntegrationVerticalFlow';
 export * from './IntegrationsList';
 export * from './IntegrationsListItem';
 export * from './IntegrationsListItemActions';
+export * from './IntegrationsListItemUnreadable';
 export * from './IntegrationsListSkeleton';
 export * from './IntegrationsListView';

--- a/syndesis/src/modules/integrations/components/Integrations.tsx
+++ b/syndesis/src/modules/integrations/components/Integrations.tsx
@@ -5,6 +5,7 @@ import {
   IntegrationsList,
   IntegrationsListItem,
   IntegrationsListItemActions,
+  IntegrationsListItemUnreadable,
   IntegrationsListSkeleton,
 } from '@syndesis/ui';
 import { WithLoader } from '@syndesis/utils';
@@ -37,104 +38,122 @@ export class Integrations extends React.Component<IIntegrationsProps> {
                     >
                       {() =>
                         this.props.integrations.map(
-                          (mi: IntegrationWithMonitoring, index) => {
-                            const editAction: IIntegrationAction = {
-                              href: resolvers.integration.edit.index({
-                                integration: mi.integration,
-                              }),
-                              label: 'Edit',
-                            };
-                            const startAction: IIntegrationAction = {
-                              label: 'Start',
-                              onClick: () => alert('todo: start'),
-                            };
-                            const stopAction: IIntegrationAction = {
-                              label: 'Stop',
-                              onClick: () => alert('todo: stop'),
-                            };
-                            const deleteAction: IIntegrationAction = {
-                              label: 'Delete',
-                              onClick: () => alert('todo: delete'),
-                            };
-                            const exportAction: IIntegrationAction = {
-                              label: 'Export',
-                              onClick: () => alert('todo: export'),
-                            };
-                            const actions: IIntegrationAction[] = [];
-                            if (canEdit(mi.integration)) {
-                              actions.push(editAction);
+                          (mi: IntegrationWithMonitoring) => {
+                            try {
+                              const editAction: IIntegrationAction = {
+                                href: resolvers.integration.edit.index({
+                                  integration: mi.integration,
+                                }),
+                                label: 'Edit',
+                              };
+                              const startAction: IIntegrationAction = {
+                                label: 'Start',
+                                onClick: () => alert('todo: start'),
+                              };
+                              const stopAction: IIntegrationAction = {
+                                label: 'Stop',
+                                onClick: () => alert('todo: stop'),
+                              };
+                              const deleteAction: IIntegrationAction = {
+                                label: 'Delete',
+                                onClick: () => alert('todo: delete'),
+                              };
+                              const exportAction: IIntegrationAction = {
+                                label: 'Export',
+                                onClick: () => alert('todo: export'),
+                              };
+                              const actions: IIntegrationAction[] = [];
+                              if (canEdit(mi.integration)) {
+                                actions.push(editAction);
+                              }
+                              if (canActivate(mi.integration)) {
+                                actions.push(startAction);
+                              }
+                              if (canDeactivate(mi.integration)) {
+                                actions.push(stopAction);
+                              }
+                              actions.push(deleteAction);
+                              actions.push(exportAction);
+                              return (
+                                <IntegrationsListItem
+                                  key={mi.integration.id}
+                                  integrationName={mi.integration.name}
+                                  currentState={mi.integration!.currentState!}
+                                  targetState={mi.integration!.targetState!}
+                                  isConfigurationRequired={
+                                    !!(
+                                      mi.integration!.board!.warnings ||
+                                      mi.integration!.board!.errors ||
+                                      mi.integration!.board!.notices
+                                    )
+                                  }
+                                  monitoringValue={
+                                    mi.monitoring &&
+                                    t(
+                                      'integrations:' +
+                                        mi.monitoring.detailedState.value
+                                    )
+                                  }
+                                  monitoringCurrentStep={
+                                    mi.monitoring &&
+                                    mi.monitoring.detailedState.currentStep
+                                  }
+                                  monitoringTotalSteps={
+                                    mi.monitoring &&
+                                    mi.monitoring.detailedState.totalSteps
+                                  }
+                                  monitoringLogUrl={getPodLogUrl(
+                                    config,
+                                    mi.monitoring
+                                  )}
+                                  startConnectionIcon={
+                                    mi.integration.flows![0].steps![0]
+                                      .connection!.icon!
+                                  }
+                                  finishConnectionIcon={
+                                    mi.integration.flows![0].steps![
+                                      mi.integration.flows![0].steps!.length - 1
+                                    ].connection!.icon!
+                                  }
+                                  actions={
+                                    <IntegrationsListItemActions
+                                      integrationId={mi.integration!.id!}
+                                      actions={actions}
+                                    />
+                                  }
+                                  i18nConfigurationRequired={t(
+                                    'integrations:ConfigurationRequired'
+                                  )}
+                                  i18nError={t('shared:Error')}
+                                  i18nPublished={t('shared:Published')}
+                                  i18nUnpublished={t('shared:Unpublished')}
+                                  i18nProgressPending={t('shared:Pending')}
+                                  i18nProgressStarting={t(
+                                    'integrations:progressStarting'
+                                  )}
+                                  i18nProgressStopping={t(
+                                    'integrations:progressStopping'
+                                  )}
+                                  i18nLogUrlText={t('shared:viewLogs')}
+                                />
+                              );
+                            } catch (e) {
+                              return (
+                                <IntegrationsListItemUnreadable
+                                  key={mi.integration.id}
+                                  integrationName={
+                                    (mi &&
+                                      mi.integration &&
+                                      mi.integration.name) ||
+                                    'An integration'
+                                  }
+                                  i18nDescription={
+                                    "Sorry, we can't display more information about this integration right now."
+                                  }
+                                  rawObject={JSON.stringify(mi.integration)}
+                                />
+                              );
                             }
-                            if (canActivate(mi.integration)) {
-                              actions.push(startAction);
-                            }
-                            if (canDeactivate(mi.integration)) {
-                              actions.push(stopAction);
-                            }
-                            actions.push(deleteAction);
-                            actions.push(exportAction);
-                            return (
-                              <IntegrationsListItem
-                                key={index}
-                                integrationName={mi.integration.name}
-                                currentState={mi.integration!.currentState!}
-                                targetState={mi.integration!.targetState!}
-                                isConfigurationRequired={
-                                  !!(
-                                    mi.integration!.board!.warnings ||
-                                    mi.integration!.board!.errors ||
-                                    mi.integration!.board!.notices
-                                  )
-                                }
-                                monitoringValue={
-                                  mi.monitoring &&
-                                  t(
-                                    'integrations:' +
-                                      mi.monitoring.detailedState.value
-                                  )
-                                }
-                                monitoringCurrentStep={
-                                  mi.monitoring &&
-                                  mi.monitoring.detailedState.currentStep
-                                }
-                                monitoringTotalSteps={
-                                  mi.monitoring &&
-                                  mi.monitoring.detailedState.totalSteps
-                                }
-                                monitoringLogUrl={getPodLogUrl(
-                                  config,
-                                  mi.monitoring
-                                )}
-                                startConnectionIcon={
-                                  mi.integration.flows![0].steps![0].connection!
-                                    .icon!
-                                }
-                                finishConnectionIcon={
-                                  mi.integration.flows![0].steps![
-                                    mi.integration.flows![0].steps!.length - 1
-                                  ].connection!.icon!
-                                }
-                                actions={
-                                  <IntegrationsListItemActions
-                                    integrationId={mi.integration!.id!}
-                                    actions={actions}
-                                  />
-                                }
-                                i18nConfigurationRequired={t(
-                                  'integrations:ConfigurationRequired'
-                                )}
-                                i18nError={t('shared:Error')}
-                                i18nPublished={t('shared:Published')}
-                                i18nUnpublished={t('shared:Unpublished')}
-                                i18nProgressPending={t('shared:Pending')}
-                                i18nProgressStarting={t(
-                                  'integrations:progressStarting'
-                                )}
-                                i18nProgressStopping={t(
-                                  'integrations:progressStopping'
-                                )}
-                                i18nLogUrlText={t('shared:viewLogs')}
-                              />
-                            );
                           }
                         )
                       }

--- a/syndesis/src/modules/integrations/components/Integrations.tsx
+++ b/syndesis/src/modules/integrations/components/Integrations.tsx
@@ -150,7 +150,11 @@ export class Integrations extends React.Component<IIntegrationsProps> {
                                   i18nDescription={
                                     "Sorry, we can't display more information about this integration right now."
                                   }
-                                  rawObject={JSON.stringify(mi.integration)}
+                                  rawObject={JSON.stringify(
+                                    mi.integration,
+                                    null,
+                                    2
+                                  )}
                                 />
                               );
                             }

--- a/syndesis/src/shared/PageTitle.tsx
+++ b/syndesis/src/shared/PageTitle.tsx
@@ -15,7 +15,7 @@ export interface IPageTitleProps {
  * visible in the browser's title bar, tab and history.
  * @see [title]{@link IPageTitleProps#title}
  */
-export class PageTitle extends React.Component<IPageTitleProps> {
+export class PageTitle extends React.PureComponent<IPageTitleProps> {
   public render() {
     return (
       <AppContext.Consumer>

--- a/syndesis/src/shared/WithErrorBoundary.tsx
+++ b/syndesis/src/shared/WithErrorBoundary.tsx
@@ -5,6 +5,10 @@ import { Translation } from 'react-i18next';
 export interface IWithErrorBoundaryState {
   error?: Error;
   errorInfo?: React.ErrorInfo;
+  errorComponent?: React.ReactElement<{
+    error: Error;
+    errorInfo: React.ErrorInfo;
+  }>;
 }
 
 export class WithErrorBoundary extends React.Component<
@@ -32,20 +36,27 @@ export class WithErrorBoundary extends React.Component<
 
   public render() {
     return this.state.error && this.state.errorInfo ? (
-      <Translation ns={['shared']}>
-        {t => (
-          <UnrecoverableError
-            i18nTitle={t('error.title')}
-            i18nInfo={t('error.info')}
-            i18nHelp={t('error.help')}
-            i18nRefreshLabel={t('error.refreshButton')}
-            i18nReportIssue={t('shared:error.reportIssueButton')}
-            i18nShowErrorInfoLabel={t('error.showErrorInfoButton')}
-            error={this.state.error}
-            errorInfo={this.state.errorInfo}
-          />
-        )}
-      </Translation>
+      this.props.errorComponent ? (
+        React.createElement(this.props.errorComponent, {
+          error: this.state.error,
+          errorInfo: this.state.errorInfo,
+        })
+      ) : (
+        <Translation ns={['shared']}>
+          {t => (
+            <UnrecoverableError
+              i18nTitle={t('error.title')}
+              i18nInfo={t('error.info')}
+              i18nHelp={t('error.help')}
+              i18nRefreshLabel={t('error.refreshButton')}
+              i18nReportIssue={t('shared:error.reportIssueButton')}
+              i18nShowErrorInfoLabel={t('error.showErrorInfoButton')}
+              error={this.state.error}
+              errorInfo={this.state.errorInfo}
+            />
+          )}
+        </Translation>
+      )
     ) : (
       this.props.children
     );


### PR DESCRIPTION
This adds a way to catch errors when rendering integration items, and shows a fallback instead. 

It is in no way to be considered the best way to deal with this kind of problem, it's just a patch; that said, I think the approach is interesting and we could try it out and in case, extend it/make it better.

## Changes

Some bogus integrations.
![Screenshot 2019-04-08 at 20 46 28](https://user-images.githubusercontent.com/966316/55748638-72faf680-5a3f-11e9-9449-9208816a1ffa.png)

What is displayed clicking on the "Integration JSON" button.
![Screenshot 2019-04-08 at 20 46 34](https://user-images.githubusercontent.com/966316/55748635-72626000-5a3f-11e9-94de-8f1e73690d62.png)
